### PR TITLE
Fix project name in Assetfile

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -7,7 +7,7 @@ distros = {
 output "dist"
 
 distros.each do |name, modules|
-  name = "ember-dev-package"
+  name = "ember-model"
 
   input "dist/modules" do
     module_paths = modules.map{|m| "#{m}.js" }


### PR DESCRIPTION
Update the project name so the built files are named dist/ember-model.js, etc. instead of dist/ember-dev-package.js.
