### PR TITLE
Make RESTAdapter#find use record.constructor.rootKey when present

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -7,12 +7,9 @@ Ember.RESTAdapter = Ember.Adapter.extend({
     var url = this.buildURL(record.constructor, id),
         rootKey = record.constructor.rootKey;
 
-    if (!rootKey) {
-      throw new Error('Ember.RESTAdapter requires a `rootKey` property to be specified');
-    }
-
     return this.ajax(url).then(function(data) {
-      Ember.run(record, record.load, id, data);
+      var dataToLoad = rootKey ? data[rootKey] : data;
+      Ember.run(record, record.load, id, dataToLoad);
     });
   },
 

--- a/packages/ember-model/tests/adapter/rest_adapter_test.js
+++ b/packages/ember-model/tests/adapter/rest_adapter_test.js
@@ -66,20 +66,15 @@ test("findAll", function() {
   Ember.run(RESTModel, RESTModel.find);
 });
 
-test("findById throws an error if rootKey isn't specified", function() {
-  expect(1);
-
-  RESTModel.rootKey = null;
-
-  throws(function() {
-    Ember.run(RESTModel, RESTModel.find, 1);
-  }, /requires a `rootKey` property to be specified/);
-});
-
 test("findById", function() {
   expect(4);
 
-  var data = { id: 1, title: "Test Title" },
+  var data = {
+        post: {
+          id: 1, 
+          name: "Test Title"
+        }
+      },
       record;
 
   adapter._ajax = function(url, params, method) {
@@ -93,7 +88,48 @@ test("findById", function() {
     record = RESTModel.find(1);
   });
 
-  deepEqual(record.get('data'), data, "The data should be properly loaded");
+  deepEqual(record.get('data'), data.post, "The data should be properly loaded");
+});
+
+test("findById loads the full JSON payload when rootKey isn't specified", function() {
+  expect(1);
+  
+  var data = {id: 1, name: "Erik"},
+      record;
+  RESTModel.rootKey = undefined;
+
+  adapter._ajax = function(url, params, method) {
+    return ajaxSuccess(data);
+  };
+
+  Ember.run(function() {
+    record = RESTModel.find(1);
+  });
+
+  equal(record.get('name'), data.name, "The data should be properly loaded");
+});
+
+test("findById loads the proper JSON payload subset when rootKey is specified", function() {
+  expect(1);
+  
+  var data = {
+        post: {
+          id: 1,
+          name: "Erik"
+        }
+      },
+    record;
+  RESTModel.rootKey = "post";
+
+  adapter._ajax = function(url, params, method) {
+    return ajaxSuccess(data);
+  };
+
+  Ember.run(function() {
+    record = RESTModel.find(1);
+  });
+
+  equal(record.get('name'), data.post.name, "The data should be properly loaded");
 });
 
 test("findQuery", function() {


### PR DESCRIPTION
For issue #34. Let me know if this aligns with your thoughts for the rootKey.
