### PR TITLE
It looks like it's merging the values incorrectly

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -62,7 +62,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, Ember.DeferredMixin, {
   },
 
   load: function(id, hash) {
-    var data = Ember.merge({id: id}, hash);
+    var data = Ember.merge({'id': id}, hash);
     set(this, 'data', data);
     set(this, 'isLoaded', true);
     set(this, 'isNew', false);


### PR DESCRIPTION
It looks like it should be merging the evaluated value of id with the id field, and not with the evaluated value field.

foo.(evalid)=(evalid)
foo.id = (evalid)
