### PR TITLE
Make findQuery actually use params

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -82,7 +82,7 @@ Ember.RESTAdapter = Ember.Adapter.extend({
 
     if (params) {
       if (method === "GET") {
-        settings.data = Ember.$.param(params);
+        settings.data = params;
       } else {
         settings.contentType = "application/json; charset=utf-8";
         settings.data = JSON.stringify(params);

--- a/packages/ember-model/tests/adapter/rest_adapter_test.js
+++ b/packages/ember-model/tests/adapter/rest_adapter_test.js
@@ -182,7 +182,7 @@ test("findQuery with params", function() {
   expect(1);
 
   Ember.$.ajax = function(settings) {
-    equal(settings.data, "foo=bar&num=42");
+    deepEqual(settings.data, {foo: 'bar', num: 42});
     return ajaxSuccess();
   };
 


### PR DESCRIPTION
The current `_ajax` function on the RESTAdapter doesn't use
passed-in params if the request is not a GET.

This pull request uses JQuerys `param` function to urlencode
the params object (in the case of a GET request). For other
HTTP verbs, the behavior stays the same.
