### PR TITLE
Add Model#reload

### DIFF
--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -41,6 +41,25 @@ test(".find(id) delegates to the adapter's find method", function() {
   });
 });
 
+test(".reload() loads the record via the adapter after it was loaded", function() {
+  expect(1);
+
+  var record = Ember.run(Model, Model.find, 1);
+
+  Model.load([{ id: 1, name: 'Yehuda' }]);
+
+  Ember.run(function() {
+    record.reload();
+  });
+
+  stop();
+
+  record.on('didLoad', function() {
+    start();
+    equal(record.get('name'), 'Erik');
+  });
+});
+
 test(".find(id) called multiple times returns the same object (identity map)", function() {
   expect(1);
 


### PR DESCRIPTION
This PR adds simple `record.reload()` functionality to reload the record's data from the server. Here are couple of use cases
- record was loaded some time ago and we want to get fresh data
- some operation causes a different record to change on the server and we want to reload it (yes, sideloading might be an option here, but reload is much simpler for simple use cases)
- record was edited and we want to reload the actual data from the server. Even though this can be done by storing the edit data somewhere else, `reload` is a much simpler solution that works most of the time

While it isn't that hard to do the reload by hand using `Model#load` and custom AJAX, this is a nice and convenient shortcut that's useful in a lot of cases.
