### PR TITLE
didCreateRecord stores the new record in identity map

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -101,7 +101,12 @@ Ember.Model = Ember.Object.extend(Ember.Evented, Ember.DeferredMixin, {
 
   didCreateRecord: function() {
     set(this, 'isNew', false);
+
+    if (!this.constructor.recordCache) this.constructor.recordCache = {};
+    this.constructor.recordCache[this.get('data.id')] = this;
+
     this.load(this.get('id'), this.getProperties(this.attributes));
+
     this.constructor.addToRecordArrays(this);
     this.trigger('didCreateRecord');
     this.didSaveRecord();


### PR DESCRIPTION
This allows for newly created records without an ID to be stored in the identity map, based on the ID that the server returns.

Before this PR

``` javascript
user = App.User.create({ name: "john" });
user.save(); // returns { id: 1, name: "john" }

App.User.find(1) // GET /users/1.json
App.User.find(1) // loaded from the identity map
```

with this patch the record is already inserted in the identity map when it is created.
