### PR TITLE
Don't convert null to object when fetching attr

### DIFF
--- a/packages/ember-model/lib/attr.js
+++ b/packages/ember-model/lib/attr.js
@@ -34,7 +34,7 @@ Ember.attr = function(type) {
       return value;
     }
 
-    if (typeof dataValue === 'object') {
+    if (dataValue && typeof dataValue === 'object') {
       dataValue = Ember.create(dataValue);
     }
     return dataValue;

--- a/packages/ember-model/tests/attr_test.js
+++ b/packages/ember-model/tests/attr_test.js
@@ -16,3 +16,17 @@ test("when the attr is specified on an object it should Object.create the object
   var newAuthorObject = page.get('author');
   ok(newAuthorObject !== originalAuthorObject, "The objects shouldn't be the same");
 });
+
+test("attr should not change null to object", function() {
+  var Page = Ember.Model.extend({
+    author: attr()
+  });
+  var page = Page.create();
+
+  Ember.run(function() {
+    page.load(1, {author: null});
+  });
+
+  var author = page.get('author');
+  equal(author, null, "author should be set to null");
+});


### PR DESCRIPTION
`typeof(null)` returns `"object"` in javascript, which was incorrectly
causing attr to call `Ember.create(null)`
