### PR TITLE
Reset isSaving to false when the record is not dirty.

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -95,6 +95,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, Ember.DeferredMixin, {
     } else {
       var deferred = Ember.Deferred.create();
       deferred.resolve(this);
+      set(this, 'isSaving', false);
       return deferred;
     }
   },

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -17,6 +17,8 @@ test("when no properties have changed on a model, save should noop", function() 
   ok(!obj.get('isDirty'));
 
   Ember.run(obj, obj.save);
+
+  ok(!obj.get('isSaving'));
 });
 
 test("when properties have changed on a model, isDirty should be set", function() {


### PR DESCRIPTION
Since saving is a noop when the record is not dirty, we don't actually call the adapter's saveRecord (or createRecord) method. Because of this, nothing ever resets the isSaving state back to false when it's "done".
