### PR TITLE
Make findQuery actually use params

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -115,9 +115,13 @@ Ember.RESTAdapter = Ember.Adapter.extend({
       dataType: "json"
     };
 
-    if (params && method !== "GET") {
-      settings.contentType = "application/json; charset=utf-8";
-      settings.data = JSON.stringify(params);
+    if (params) {
+      if (method === "GET") {
+        settings.data = params;
+      } else {
+        settings.contentType = "application/json; charset=utf-8";
+        settings.data = JSON.stringify(params);
+      }
     }
 
     return Ember.$.ajax(settings);

--- a/packages/ember-model/tests/adapter/rest_adapter_test.js
+++ b/packages/ember-model/tests/adapter/rest_adapter_test.js
@@ -408,6 +408,17 @@ test("findQuery calls didFindQuery callback after finishing", function() {
   equal(context, adapter, "context of didFindQuery should have been set to adapter");
 });
 
+test("findQuery with params", function() {
+  expect(1);
+
+  Ember.$.ajax = function(settings) {
+    deepEqual(settings.data, {foo: 'bar', num: 42});
+    return ajaxSuccess();
+  };
+
+  Ember.run(RESTModel, RESTModel.find, {foo: 'bar', num: 42});
+});
+
 test("createRecord", function() {
   expect(5);
 


### PR DESCRIPTION
The current `_ajax` function on the RESTAdapter doesn't use
passed-in params if the request is not a GET.

This pull request uses JQuerys `param` function to urlencode
the params object (in the case of a GET request). For other
HTTP verbs, the behavior stays the same.
