### PR TITLE
Should respect rootKey from create response as well as when finding

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -61,6 +61,9 @@ Ember.RESTAdapter = Ember.Adapter.extend({
   },
 
   didCreateRecord: function(record, data) {
+    var rootKey = get(record.constructor, 'rootKey'),
+        dataToLoad = rootKey ? data[rootKey] : data;
+
     Ember.run(function() {
       record.load(data.id, data); // FIXME: hardcoded ID
       record.didCreateRecord();


### PR DESCRIPTION
If the model has a rootKey, it should be respected for the response when creating a record as well as when finding a record.
