### PR TITLE
Support objects with no ID

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -286,7 +286,12 @@ Ember.Model.reopenClass({
 
   // FIXME
   findFromCacheOrLoad: function(data) {
-    var record = this.cachedRecordForId(data.id);
+    var record;
+    if (!data.id) {
+      record = this.create({isLoaded: false});
+    } else {
+      record = this.cachedRecordForId(data.id);
+    }
     // set(record, 'data', data);
     record.load(data.id, data);
     return record;

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -1,4 +1,4 @@
-var Model;
+var Model, ModelWithoutID;
 
 module("Ember.Model", {
   setup: function() {
@@ -8,6 +8,12 @@ module("Ember.Model", {
     Model.adapter = Ember.FixtureAdapter.create();
     Model.FIXTURES = [
       {id: 1, name: 'Erik'}
+    ];
+    ModelWithoutID = Model.extend();
+    ModelWithoutID.adapter = Ember.FixtureAdapter.create();
+    ModelWithoutID.FIXTURES = [
+      {name: 'Erik'},
+      {name: 'Alex'}
     ];
   },
   teardown: function() {
@@ -19,6 +25,19 @@ test("can define attributes with Ember.attr, data is accessible", function() {
   var instance = Model.create({name: "Erik"});
 
   equal(instance.get('name'), "Erik", "Property value was retained");
+});
+
+test("can handle models without an ID", function() {
+  expect(3);
+  var records = ModelWithoutID.find();
+  stop();
+  records.on('didLoad', function() {
+    start();
+    equal(records.get('length'), 2);
+    equal(records.get('firstObject.name'), 'Erik');
+    equal(records.get('lastObject.name'), 'Alex');
+  });
+
 });
 
 // test("coercion", function() {


### PR DESCRIPTION
Some objects don't have IDs and it doesn't make sense for them to have ids. In my case this is for aggregates that are generated in mysql using `GROUP BY` on the fly - it doesn't make sense for the result of a MySQL group by query to have an ID. Currently without this patch, the recordCache uses the cache key undefined, resulting in an array of objects that all have identical attributes
