### PR TITLE
Add tests for isDirty with Array attr updates

### DIFF
--- a/packages/ember-model/tests/adapter/rest_adapter_test.js
+++ b/packages/ember-model/tests/adapter/rest_adapter_test.js
@@ -589,3 +589,27 @@ test("saveRecord received the array correctly inside params", function() {
 
   ok(!record.get('isDirty'), "Record should not be dirty");
 });
+
+test("saveRecord will run after an array update", function() {
+  expect(3);
+
+  var record = Ember.run(RESTModel, RESTModel.create, {id: 1, names: Ember.A(), isNew: false});
+
+  var new_name = 'Bill';
+  record.get('names').pushObject(new_name);
+
+  ok(record.get('isDirty'), "Record should be dirty");
+
+  adapter._ajax = function(url, params, method) {
+    return ajaxSuccess({id: 1, names: [new_name]});
+  };
+
+  Ember.run(record, record.save);
+
+  ok(!record.get('isDirty'), "Record should not be dirty");
+
+  var second_name = 'Erik';
+  record.get('names').pushObject(second_name);
+
+  ok(record.get('isDirty'), "Record should be dirty after adding to the array");
+});

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -36,7 +36,6 @@ test("when properties have changed on a model, isDirty should be set", function(
 
   var obj = Ember.run(Model, Model.create, {isNew: false});
   ok(!obj.get('isDirty'));
-
   obj.set('name', 'Jeffrey');
   ok(obj.get('isDirty'));
 
@@ -162,4 +161,27 @@ test("dirty checking works for nested objects", function() {
   ok(obj.get('isDirty'));
   obj.set('author.name.first', "Erik");
   ok(!obj.get('isDirty')); // FIXME - this fails
+});
+
+test("dirty checking works for arrays", function() {
+  var Model = Ember.Model.extend({
+    author_list: attr(Ember.A())
+  });
+
+  Model.adapter = {
+    saveRecord: function() {
+      ok(true, "saveRecord was called");
+    }
+  };
+
+  var obj = Model.create();
+  Ember.run(function() {
+    obj.load(1, {author_list: Ember.A()});
+  });
+
+  ok(!obj.get('isDirty'));
+  obj.get('author_list').pushObject('Chris');
+  ok(obj.get('isDirty'));
+  obj.get('author_list').removeObject('Chris');
+  ok(!obj.get('isDirty'));
 });


### PR DESCRIPTION
Running into further issues with `saveRecord` not running after updating an array attribute. Added a couple tests to try to work it out.

The test that is directly for `isDirty` appears to work correctly, but in the `saveRecord` test, array updates do not trigger dirtiness.

Feel free to advise if I'm on the wrong track in either case.
