### PR TITLE
Add failing test for Model.findMany

### DIFF
--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -194,6 +194,17 @@ test("Model.find(id) returns a deferred", function() {
   stop();
 });
 
+test("Model.findMany(ids) returns a deferred", function() {
+  expect(1);
+
+  var record = Ember.run(Model, Model.findMany, [1]);
+  record.then(function(data) {
+    start();
+    ok(data.get('isLoaded'));
+  });
+  stop();
+});
+
 test("Model#save() returns a deferred", function() {
   expect(2);
 


### PR DESCRIPTION
This seems to be working fine with RESTAdapter, but it's failing for the FixtureAdapter. I'm not sure if I'm missing something
