### PR TITLE
Add failing test for array attributes

### DIFF
--- a/packages/ember-model/tests/adapter/rest_adapter_test.js
+++ b/packages/ember-model/tests/adapter/rest_adapter_test.js
@@ -589,3 +589,18 @@ test("saveRecord received the array correctly inside params", function() {
 
   ok(!record.get('isDirty'), "Record should not be dirty");
 });
+
+test("arrays work as expected", function() {
+  expect(1);
+
+  var record = Ember.run(RESTModel, RESTModel.create, {id: 1, names: Ember.A(), isNew: false});
+
+  adapter._ajax = function(url, params, method) {
+    return ajaxSuccess({id: 1, names: ['Bill']});
+  };
+
+  Ember.run(record, record.save);
+
+  equal(record.get('names.firstObject'), 'Bill');
+  equal(record.get('data.names.firstObject'), 'Bill');
+});


### PR DESCRIPTION
It seems that if a different array value is returned from the server it is not available on the record.
