### PR TITLE
Be smarter about dirty checking cached vs. uncached.

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -23,6 +23,13 @@ function concatUnique(toArray, fromArray) {
   return toArray;
 }
 
+function hasCachedValue(object, key) {
+  var objectMeta = meta(object, false);
+  if (objectMeta) {
+    return key in objectMeta.cache;
+  }
+}
+
 Ember.run.queues.push('data');
 
 Ember.Model = Ember.Object.extend(Ember.Evented, Ember.DeferredMixin, {
@@ -39,6 +46,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, Ember.DeferredMixin, {
 
     for (var i = 0, l = attributes.length; i < l; i++) {
       key = attributes[i];
+      if (!hasCachedValue(this, key)) { continue; }
       cachedValue = this.cacheFor(key);
       dataValue = get(this, 'data.'+this.dataKey(key));
       desc = meta(this).descs[key];
@@ -46,8 +54,8 @@ Ember.Model = Ember.Object.extend(Ember.Evented, Ember.DeferredMixin, {
       type = descMeta.type;
 
       if (type && type.isEqual) {
-        isDirty = !type.isEqual(dataValue, cachedValue || dataValue);
-      } else if (dataValue !== (cachedValue || dataValue)) {
+        isDirty = !type.isEqual(dataValue, cachedValue);
+      } else if (dataValue !== cachedValue) {
         isDirty = true;
       } else {
         isDirty = false;

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -163,3 +163,18 @@ test("dirty checking works for nested objects", function() {
   obj.set('author.name.first', "Erik");
   ok(!obj.get('isDirty')); // FIXME - this fails
 });
+
+test("dirty checking works with boolean attributes", function() {
+  var Model = Ember.Model.extend({
+    canSwim: attr(Boolean)
+  });
+
+  var obj = Model.create();
+  Ember.run(function() {
+    obj.load(1, {canSwim: true});
+  });
+
+  ok(!obj.get('isDirty'));
+  obj.set('canSwim', false);
+  ok(obj.get('isDirty'), "toggling a boolean value makes the record dirty");
+});


### PR DESCRIPTION
Doing an `||` check makes boolean values, numeric values, and string values possibly behave incorrectly in the dirty checking code.
