### PR TITLE
[WIP] Partially loaded recrods

### DIFF
--- a/packages/ember-model/lib/attr.js
+++ b/packages/ember-model/lib/attr.js
@@ -70,6 +70,10 @@ Ember.attr = function(type) {
         dataValue = data && get(data, dataKey),
         beingCreated = meta(this).proto === this;
 
+    if(this.get('isPartiallyLoaded') && this.isAttributeMissing(key)) {
+     this.missingAttributeAccessed(key);
+    }
+
     if (arguments.length === 2) {
       if (beingCreated && !data) {
         data = {};

--- a/packages/ember-model/tests/partially_loaded_model_test.js
+++ b/packages/ember-model/tests/partially_loaded_model_test.js
@@ -1,0 +1,50 @@
+var Model;
+
+module("Partially loaded records", {
+  setup: function() {
+    Model = Ember.Model.extend({
+      id: Ember.attr(),
+      name: Ember.attr()
+    });
+
+    Model.adapter = Ember.FixtureAdapter.create();
+  }
+});
+
+test("missingAttributeAccessed is called if the attribute is not loaded", function() {
+  expect(1);
+
+  var key, record = Model.create({ isLoaded: false });
+  Ember.run(function() {
+    record.load(1, {});
+  });
+
+  record.missingAttributeAccessed = function(_key) {
+    key = _key;
+  };
+
+  record.get('name');
+
+  equal(key, 'name', 'missingAttributeAccessed should be called with attribute name "key".');
+});
+
+test("missingAttributeAccessed is not called if the attribute is loaded", function() {
+  expect(0);
+
+  var key, record = Model.create({ isLoaded: false });
+  Ember.run(function() {
+    record.load(1, { name: 'Erik' });
+  });
+
+  record.missingAttributeAccessed = function(_key) {
+    key = _key;
+  };
+
+  record.get('name');
+
+  record.missingAttributeAccessed = function(_key) {
+    equal(true, false, "missingAttributeAccessed should not be called");
+  };
+
+  record.get('name');
+});


### PR DESCRIPTION
I've done a first _realy_ simple stab at partially loaded records and I would like to start a discussion about it. It will need to expose new APIs, so I would like to have a blessing before going to deep into implementation.

The purpose of partially loaded records is to allow creating a record from partial data and act if the missing data is accessed. For example we may have a blog with a `Post` model, which has 2 attributes: `title` and `body`. A body can be quite big and we don't show it on the list of posts, so to make the posts list to load turbofast, we can just return a representation containing `title` and load `body` only if a visitor goes to detailed post view.

The code could look like this:

``` javascript
var Post = Ember.Model.extend({
  id: attr(String),
  title: attr(String),
  body: attr(String),

  missingAttributeAccessed: function(key) {
    // reload record if we're missing any attributes
    this.reload();
  }
});

Post.loadPartially({
  id: '1',
  title: 'Really long blog post'
});

var post = Post.find('1');

post.get('title'); // => 'Really long blog post'

post.get('body'); // => null
// at this point missingAttributeAccessed is called
```

Current implementation ignores associations, mainly because I would like to implement `belongsTo` and `hasMany` without embedded data before I continue work on this.

Any feedback and comments on both implementation and public API is welcomed.

TODO:
- [ ] add isPartiallyLoaded computed property, so people can observe it
- [ ] add a way to indicate that the record is fully loaded
- [ ] support associations
- [ ] consider creating a public API so this can be implemented as an extension (is it worth it?)
