### PR TITLE
[WIP] Remove Ember.DeferredMixin from model and RecordArray

### DIFF
--- a/packages/ember-model/lib/load_promise.js
+++ b/packages/ember-model/lib/load_promise.js
@@ -1,0 +1,27 @@
+var get = Ember.get;
+
+Ember.LoadPromise = Ember.Object.extend(Ember.DeferredMixin, {
+  init: function() {
+    this._super.apply(this, arguments);
+
+    var target = get(this, 'target');
+
+    if (get(target, 'isLoaded') && !get(target, 'isNew')) {
+      this.resolve(target);
+    } else {
+      target.one('didLoad', this, function() {
+        this.resolve(target);
+      });
+    }
+  }
+});
+
+Ember.loadPromise = function(target) {
+  if (Ember.isNone(target)) {
+    return null;
+  } else if (target.then) {
+    return target;
+  } else {
+    return Ember.LoadPromise.create({target: target});
+  }
+};

--- a/packages/ember-model/lib/main.js
+++ b/packages/ember-model/lib/main.js
@@ -7,3 +7,4 @@ require('ember-model/model');
 require('ember-model/has_many');
 require('ember-model/attr');
 require('ember-model/rest_adapter');
+require('ember-model/load_promise');

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -32,7 +32,7 @@ function hasCachedValue(object, key) {
 
 Ember.run.queues.push('data');
 
-Ember.Model = Ember.Object.extend(Ember.Evented, Ember.DeferredMixin, {
+Ember.Model = Ember.Object.extend(Ember.Evented, {
   isLoaded: true,
   isLoading: Ember.computed.not('isLoaded'),
   isNew: true,
@@ -92,7 +92,6 @@ Ember.Model = Ember.Object.extend(Ember.Evented, Ember.DeferredMixin, {
   },
 
   init: function() {
-    if (!get(this, 'isNew')) { this.resolve(this); }
     this._super();
   },
 
@@ -103,7 +102,6 @@ Ember.Model = Ember.Object.extend(Ember.Evented, Ember.DeferredMixin, {
     set(this, 'isLoaded', true);
     set(this, 'isNew', false);
     this.trigger('didLoad');
-    this.resolve(this);
   },
 
   didDefineProperty: function(proto, key, value) {
@@ -144,9 +142,9 @@ Ember.Model = Ember.Object.extend(Ember.Evented, Ember.DeferredMixin, {
     var adapter = this.constructor.adapter;
     set(this, 'isSaving', true);
     if (get(this, 'isNew')) {
-      return adapter.createRecord(this);
+      return Ember.loadPromise(adapter.createRecord(this));
     } else if (get(this, 'isDirty')) {
-      return adapter.saveRecord(this);
+      return Ember.loadPromise(adapter.saveRecord(this));
     } else {
       var deferred = Ember.Deferred.create();
       deferred.resolve(this);
@@ -335,7 +333,7 @@ Ember.Model.reopenClass({
       }
     }
 
-    recordOrRecordArray.then(function() {
+    Ember.loadPromise(recordOrRecordArray).then(function() {
       for (var i = 0, l = batchRecordArrays.length; i < l; i++) {
         batchRecordArrays[i].loadForFindMany(self);
       }

--- a/packages/ember-model/lib/record_array.js
+++ b/packages/ember-model/lib/record_array.js
@@ -1,7 +1,7 @@
 var get = Ember.get,
     set = Ember.set;
 
-Ember.RecordArray = Ember.ArrayProxy.extend(Ember.Evented, Ember.DeferredMixin, {
+Ember.RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
   isLoaded: false,
   isLoading: Ember.computed.not('isLoaded'),
 
@@ -19,7 +19,6 @@ Ember.RecordArray = Ember.ArrayProxy.extend(Ember.Evented, Ember.DeferredMixin, 
   notifyLoaded: function() {
     set(this, 'isLoaded', true);
     this.trigger('didLoad');
-    this.resolve(this);
   },
 
   materializeData: function(klass, data) {

--- a/packages/ember-model/tests/adapter/find_many_test.js
+++ b/packages/ember-model/tests/adapter/find_many_test.js
@@ -27,7 +27,8 @@ test(".find([]) delegates to the adapter's findMany method", function() {
   equal(records.get('length'), 0, "RecordArray is empty when not resolved yet");
 
   stop();
-  Ember.run(records, records.then, function() {
+  var promise = Ember.loadPromise(records);
+  Ember.run(promise, promise.then, function() {
     start();
     equal(records.get('length'), 3, "RecordArray#length is 3 after resolved");
     ok(records.get('isLoaded'), "RecordArray is loaded after resolved");

--- a/packages/ember-model/tests/adapter/find_query_test.js
+++ b/packages/ember-model/tests/adapter/find_query_test.js
@@ -22,7 +22,8 @@ test(".find({}) delegates to the adapter's findQuery method", function() {
   ok(!(Model.recordArrays || Ember.A()).contains(records), "The RecordArray created by a findQuery should not be registered");
 
   stop();
-  Ember.run(records, records.then, function() {
+  var promise = Ember.loadPromise(records);
+  Ember.run(promise, promise.then, function() {
     start();
     ok(records.get('isLoaded'), "RecordArray is loaded after resolved");
   });

--- a/packages/ember-model/tests/filtered_record_array_test.js
+++ b/packages/ember-model/tests/filtered_record_array_test.js
@@ -38,7 +38,7 @@ test("must be created with a filterProperties property", function() {
 test("with a noop filter will return all the loaded records", function() {
   expect(1);
 
-  Model.find().then(function() {
+  Ember.loadPromise(Model.find()).then(function() {
     start();
 
     var recordArray = Ember.FilteredRecordArray.create({
@@ -56,7 +56,7 @@ test("with a noop filter will return all the loaded records", function() {
 test("with a filter will return only the relevant loaded records", function() {
   expect(2);
 
-  Model.find().then(function() {
+  Ember.loadPromise(Model.find()).then(function() {
     start();
 
     var recordArray = Ember.FilteredRecordArray.create({
@@ -77,7 +77,7 @@ test("with a filter will return only the relevant loaded records", function() {
 test("loading a record that doesn't match the filter after creating a FilteredRecordArray shouldn't change the content", function() {
   expect(2);
 
-  Model.find().then(function() {
+  Ember.loadPromise(Model.find()).then(function() {
     start();
     var recordArray = Ember.FilteredRecordArray.create({
       modelClass: Model,
@@ -101,7 +101,7 @@ test("loading a record that doesn't match the filter after creating a FilteredRe
 test("loading a record that matches the filter after creating a FilteredRecordArray should update the content of it", function() {
   expect(3);
 
-  Model.find().then(function() {
+  Ember.loadPromise(Model.find()).then(function() {
     start();
     var recordArray = Ember.FilteredRecordArray.create({
       modelClass: Model,
@@ -126,7 +126,7 @@ test("loading a record that matches the filter after creating a FilteredRecordAr
 test("changing a property that matches the filter should update the FilteredRecordArray to include it", function() {
   expect(5);
 
-  Model.find().then(function() {
+  Ember.loadPromise(Model.find()).then(function() {
     start();
     var recordArray = Ember.FilteredRecordArray.create({
       modelClass: Model,
@@ -139,7 +139,7 @@ test("changing a property that matches the filter should update the FilteredReco
     equal(recordArray.get('length'), 1, "There is 1 record initially");
     equal(recordArray.get('firstObject.name'), 'Erik', "The record data matches");
 
-    Model.find(2).then(function(record) {
+    Ember.loadPromise(Model.find(2)).then(function(record) {
       record.set('name', 'Estefan');
 
       equal(recordArray.get('length'), 2, "There are 2 records after changing the name");
@@ -154,7 +154,7 @@ test("changing a property that matches the filter should update the FilteredReco
 test("adding a new record and changing a property that matches the filter should update the FilteredRecordArray to include it", function() {
   expect(5);
 
-  Model.find().then(function() {
+  Ember.loadPromise(Model.find()).then(function() {
     start();
     var recordArray = Ember.FilteredRecordArray.create({
       modelClass: Model,

--- a/packages/ember-model/tests/find_coalescing.js
+++ b/packages/ember-model/tests/find_coalescing.js
@@ -67,7 +67,8 @@ test("coalesced findMany returns a resolved promise even if all records are load
   Ember.run(record2, record.didCreateRecord);
   Ember.run(record2, record.load, 2);
 
-  var promise = Ember.run(Model, Model.find, [1, 2]);
+  var records = Ember.run(Model, Model.find, [1, 2]),
+      promise = Ember.run(Ember, Ember.loadPromise, records);
 
   Ember.run(function() {
     promise.then(function(records) {
@@ -143,11 +144,11 @@ test("should resolve all RecordArrays", function() {
     recordArray1 = Model.find([2, 3]);
     recordArray2 = Model.find([1, 2, 3]);
 
-    recordArray1.then(function() {
+    Ember.loadPromise(recordArray1).then(function() {
       ok(true, "The first RecordArray returned from findMany was loaded");
     });
 
-    recordArray2.then(function() {
+    Ember.loadPromise(recordArray2).then(function() {
       ok(true, "The second RecordArray returned from findMany was loaded");
     });
   });

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -202,7 +202,7 @@ test("Model.find() returns a deferred", function() {
   expect(2);
 
   var records = Ember.run(Model, Model.find);
-  records.then(function(data) {
+  Ember.loadPromise(records).then(function(data) {
     start();
     equal(records, data);
     ok(data.get('isLoaded'));
@@ -214,7 +214,7 @@ test("Model.find(id) returns a deferred", function() {
   expect(2);
 
   var record = Ember.run(Model, Model.find, 'a');
-  record.then(function(data) {
+  Ember.loadPromise(record).then(function(data) {
     start();
     equal(record, data);
     ok(data.get('isLoaded'));
@@ -226,7 +226,7 @@ test("Model#save() returns a deferred", function() {
   expect(2);
 
   var record = Ember.run(Model, Model.find, 'a');
-  record.then(function(data) {
+  Ember.loadPromise(record).then(function(data) {
     start();
     record.set('name', 'Stefan');
     record.save().then(function(data) {
@@ -243,7 +243,7 @@ test("Model#deleteRecord() returns a deferred", function() {
   expect(2);
 
   var record = Ember.run(Model, Model.find, 'a');
-  record.then(function(data) {
+  Ember.loadPromise(record).then(function(data) {
     start();
     record.deleteRecord().then(function(data) {
       start();
@@ -261,7 +261,7 @@ test("Model#save() works as expected", function() {
   var records = Ember.run(Model, Model.find);
   var record = Ember.run(Model, Model.find, 'a');
 
-  records.then(function() {
+  Ember.loadPromise(records).then(function() {
     start();
     ok(!record.get('isNew'));
 

--- a/packages/ember-model/tests/record_array_test.js
+++ b/packages/ember-model/tests/record_array_test.js
@@ -23,14 +23,15 @@ module("Ember.RecordArray", {
 // });
 
 test("when called with findMany, should contain an array of the IDs contained in the RecordArray", function() {
-  var records = Ember.run(Model, Model.find, [1,2,3]);
+  var records = Ember.run(Model, Model.find, [1,2,3]),
+      promise = Ember.loadPromise(records);
 
   deepEqual(records.get('_ids'), [1,2,3]);
   equal(records.get('length'), 0);
   ok(!records.get('isLoaded'));
   stop();
 
-  Ember.run(records, records.then, function() {
+  Ember.run(promise, promise.then, function() {
     start();
     equal(records.get('length'), 3);
   });


### PR DESCRIPTION
I've took a stab at this to see how much thins will need changing. I went with `Ember.loadPromise` implementation, which wraps any object, which uses `isLoading` and `didLoad` event. This seems a nice approach, because any object following such contract will work out of the box. The only issue is that because of the model's specifics I need to check for `isNew` as well, which makes `LoadPromise` more tightly coupled with model.

This PR may wait until a related API is settled for ED as well, so EM can stay compatible.
