### PR TITLE
Prevent creating models using camelizeKeys from losing track of data.

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -243,7 +243,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
     if (!this.constructor.recordCache) this.constructor.recordCache = {};
     this.constructor.recordCache[id] = this;
 
-    this.load(id, this.getProperties(this.attributes));
+    this._copyDirtyAttributesToData();
     this.constructor.addToRecordArrays(this);
     this.trigger('didCreateRecord');
     this.didSaveRecord();

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -403,6 +403,28 @@ test("toJSON includes non-embedded relationships", function() {
   equal(json.author, 1, "JSON should contain id of belongsTo relationship");
 });
 
+test("creating a record with camelizedKeys = true works as expected", function() {
+  expect(1);
+
+  var Page = Ember.Model.extend({
+    someAuthor: Ember.attr()
+  });
+  Page.camelizeKeys = true;
+  Page.adapter = Ember.FixtureAdapter.create();
+  Page.FIXTURES = [];
+
+  var record = Page.create({someAuthor: 'Brian'});
+
+  record.save();
+  stop();
+
+  record.on('didCreateRecord', function() {
+    start();
+
+    equal(record.get('someAuthor'), 'Brian', 'preserves data keys on didCreateRecord');
+  });
+});
+
 // TODO: test that creating a record calls load
 
 // test('Model#registerRecordArray', function(){


### PR DESCRIPTION
@ebryn 

When using `camelizeKeys` Ember.Model's internal `data` hash stores everything with underscored keys. The line in model.js that is replaced here was overriding the underscored data with camelized data, preventing access to keys where the camelized and underscored are different (e.g. `firstName`).
