### PR TITLE
Check that findMany is implemented by the adapter

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -402,7 +402,7 @@ Ember.Model.reopenClass({
   _fetchById: function(record, id) {
     var adapter = get(this, 'adapter');
 
-    if (adapter.findMany) {
+    if (adapter.hasOwnProperty('findMany')) {
       if (this._currentBatchIds) {
         if (!contains(this._currentBatchIds, id)) { this._currentBatchIds.push(id); }
       } else {

--- a/packages/ember-model/tests/adapter/find_many_test.js
+++ b/packages/ember-model/tests/adapter/find_many_test.js
@@ -37,3 +37,19 @@ test(".find([]) delegates to the adapter's findMany method", function() {
   });
 });
 
+test("should not call findMany when not implemented by adapter", function() {
+  expect(2);
+
+  var Model = Ember.Model.extend(),
+      Adapter = Ember.Adapter.extend({
+        find: function() {
+          ok(true, 'find was called');
+        }
+      });
+
+  Model.adapter = Adapter.create();
+  Ember.run(function() {
+    Model.find(1);
+    Model.find(2);
+  });
+});


### PR DESCRIPTION
This isn't perfect. If someone extends an adapter that does implement findMany then this won't use the base class. In that circumstance you'll have to override it and return _super. Seems slightly better than having to set findMany to null.
