### PR TITLE
Added an options.key to Ember.attr()

### DIFF
--- a/packages/ember-model/lib/attr.js
+++ b/packages/ember-model/lib/attr.js
@@ -63,7 +63,7 @@ function deserialize(value, type) {
 }
 
 
-Ember.attr = function(type) {
+Ember.attr = function(type, options) {
   return Ember.computed(function(key, value) {
     var data = get(this, 'data'),
         dataKey = this.dataKey(key),
@@ -80,5 +80,5 @@ Ember.attr = function(type) {
     }
 
     return this.getAttr(key, deserialize(dataValue, type));
-  }).property('data').meta({isAttribute: true, type: type});
+  }).property('data').meta({isAttribute: true, type: type, options: options});
 };

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -88,6 +88,10 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
 
   dataKey: function(key) {
     var camelizeKeys = get(this.constructor, 'camelizeKeys');
+    var meta = this.constructor.metaForProperty(key);
+    if (meta.options && meta.options.key) {
+      return camelizeKeys ? underscore(meta.options.key) : meta.options.key;
+    }
     return camelizeKeys ? underscore(key) : key;
   },
 

--- a/packages/ember-model/tests/attr_test.js
+++ b/packages/ember-model/tests/attr_test.js
@@ -213,3 +213,20 @@ test("attr should camelize attributes when writing", function() {
   var json = page.toJSON();
   equal(json.some_author, "Alex", "json.some_author should be set to Alex");
 });
+
+test("toJSON should respect the key option in attr", function() {
+  var Page = Ember.Model.extend({
+    author: attr(String, { key: 'Author'})
+  });
+  var page = Page.create();
+
+  Ember.run(function() {
+    page.load(1, { Author: "Guilherme" });
+  });
+
+  var json = page.toJSON();
+  equal(page.get('author'), "Guilherme", "author should be Guilherme");
+  equal(page.get('Author'), undefined, "Author should be undefined");
+  equal(json.Author, "Guilherme", "json.Author should be Guilherme");
+  equal(json.author, undefined, "json.author should be undefined");
+});


### PR DESCRIPTION
I'm not sure what the desired behavior would be for when `camelizeKeys` is true.
It uses the dataKey method now and added some tests.
