### PR TITLE
createAndBind method for adding objects to RecordArrays on creation

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -338,6 +338,12 @@ Ember.Model.reopenClass({
 
   _clientIdCounter: 1,
 
+  createAndBind: function() {
+    var record = this.create.apply(this, arguments);
+    record.constructor.addToRecordArrays(record);
+    return record;
+  },
+
   fetch: function() {
     return Ember.loadPromise(this.find.apply(this, arguments));
   },
@@ -489,6 +495,9 @@ Ember.Model.reopenClass({
   },
 
   addToRecordArrays: function(record) {
+    if (record.get('isAdded')) return;
+    record.set('isAdded', true);
+
     if (this._findAllRecordArray) {
       this._findAllRecordArray.pushObject(record);
     }


### PR DESCRIPTION
As mentioned in #9, here's a first stab at offering the ability to create a model instance and instantaneously add it to RecordArrays without waiting for save.

I opted to create a new method, `createAndBind()`, rather than overloading `create` in order to preserve the API for users who already rely on the current `create()` behavior.

Each instance now also tracks its own `isAdded` state, so it's never added twice when `save()` is called after `createAndBind()`.

And, actually, I just checked and realized this is still in 0.0.4, so if you'd prefer to make the API change, I can send a PR for the `create()` overload with the `addToRecordArrays()` call dropped from the `save()` method.
