### PR TITLE
Use Ember.run.later instead of setTimeout in FixtureAdapter

### DIFF
--- a/packages/ember-model/lib/fixture_adapter.js
+++ b/packages/ember-model/lib/fixture_adapter.js
@@ -16,10 +16,10 @@ Ember.FixtureAdapter = Ember.Adapter.extend({
     var data = this._findData(record.constructor, id);
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      setTimeout(function() {
+      Ember.run.later(this, function() {
         Ember.run(record, record.load, id, data);
         resolve(record);
-      });
+      }, 0);
     });
   },
 
@@ -32,10 +32,10 @@ Ember.FixtureAdapter = Ember.Adapter.extend({
     }
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      setTimeout(function() {
+      Ember.run.later(this, function() {
         Ember.run(records, records.load, klass, requestedData);
         resolve(records);
-      });
+      }, 0);
     });
   },
 
@@ -43,10 +43,10 @@ Ember.FixtureAdapter = Ember.Adapter.extend({
     var fixtures = klass.FIXTURES;
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      setTimeout(function() {
+      Ember.run.later(this, function() {
         Ember.run(records, records.load, klass, fixtures);
         resolve(records);
-      });
+      }, 0);
     });
   },
 
@@ -55,29 +55,29 @@ Ember.FixtureAdapter = Ember.Adapter.extend({
         fixtures = klass.FIXTURES;
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      setTimeout(function() {
+      Ember.run.later(this, function() {
         fixtures.push(klass.findFromCacheOrLoad(record.toJSON()));
         record.didCreateRecord();
         resolve(record);
-      });
+      }, 0);
     });
   },
 
   saveRecord: function(record) {
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      setTimeout(function() {
+      Ember.run.later(this, function() {
         record.didSaveRecord();
         resolve(record);
-      });
+      }, 0);
     });
   },
 
   deleteRecord: function(record) {
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      setTimeout(function() {
+      Ember.run.later(this, function() {
         record.didDeleteRecord();
         resolve(record);
-      });
+      }, 0);
     });
   }
 });


### PR DESCRIPTION
This is pretty straightforward, but I wanted to get feedback on 2 things:
1. `Ember.run.later` does not let to skip `delay` argument, so I used 0. I guess it doesn't matter really that much in this case, but it would be nice to know if this is ok to do.
2. I'm not sure if this can be tested easily, should I just skip tests?
