### PR TITLE
Support setting belongsTo with an ID

### DIFF
--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -18,11 +18,15 @@ Ember.belongsTo = function(type, options) {
 
     if (arguments.length === 2) {
       if (value) {
+        if (typeof value === "string" || typeof value === "number") {
+          value = type.find(value);
+        }
+
         Ember.assert(Ember.String.fmt('Attempted to set property of type: %@ with a value of type: %@',
                      [value.constructor, type]),
                      value instanceof type);
       }
-      return value === undefined ? null : value;  
+      return value === undefined ? null : value;
     } else {
       return this.getBelongsTo(relationshipKey, type, meta);
     }

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -300,6 +300,37 @@ test("setting relationship should make parent dirty", function() {
   ok(post.get('isDirty'));
 });
 
+test("setting relationship using the ID should work", function() {
+  expect(2);
+
+  var Author = Ember.Model.extend({
+        id: Ember.attr(),
+        name: Ember.attr()
+      }),
+      Post = Ember.Model.extend({
+        id: Ember.attr(),
+        author: Ember.belongsTo(Author, {key: 'author_id'})
+      });
+
+  Post.adapter = Ember.FixtureAdapter.create();
+  Author.adapter = Ember.FixtureAdapter.create();
+  Author.FIXTURES = [{ id: 100, name: 'bob' }];
+
+  var post = Post.create();
+  Ember.run(post, post.load, 1, { article_id: 100 });
+  Ember.run(function() {
+    post.set('author', 100);
+  });
+  var author = Ember.run(post, post.get, 'author');
+
+  stop();
+  author.one('didLoad', function() {
+    start();
+    equal(author.get('id'), 100);
+    ok(author instanceof Author);
+  });
+});
+
 test("relationships should be seralized when specified with string", function() {
   expect(1);
 


### PR DESCRIPTION
This is primarily driven by select lists whose `optionValuePath` is `content.id` (it's awkward to fill in an `Ember.Select` whose `optionValuePath` is `content`). This makes testing easier as well as it'll be a straight `fillIn(.., 123)`.

ED does a similar lookup.
