### PR TITLE
isDirty fixes

### DIFF
--- a/packages/ember-model/lib/attr.js
+++ b/packages/ember-model/lib/attr.js
@@ -76,9 +76,11 @@ Ember.attr = function(type, options) {
         beingCreated = meta(this).proto === this;
 
     if (arguments.length === 2) {
-      if (beingCreated && !data) {
-        data = {};
-        set(this, '_data', data);
+      if (beingCreated) {
+        if (!data) {
+          data = {};
+          set(this, '_data', data);
+        }
         data[dataKey] = value;
       }
       return wrapObject(value);

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -42,11 +42,17 @@ function extractDirty(object, attrsOrRelations, dirtyAttributes) {
     type = descMeta.type;
     dataType = Ember.Model.dataTypes[type];
 
+    if (descMeta.kind === 'belongsTo' && dataValue === undefined) {
+      dataValue = null;
+    }
+
     if (type && type.isEqual) {
       isDirty = !type.isEqual(dataValue, cachedValue);
     } else if (dataType && dataType.isEqual) {
       isDirty = !dataType.isEqual(dataValue, cachedValue);
     } else if (dataValue && cachedValue instanceof Ember.Model) { // belongsTo case
+      isDirty = get(cachedValue, 'isDirty');
+    } else if (dataValue === undefined && cachedValue instanceof Ember.ManyArray) { // hasMany case
       isDirty = get(cachedValue, 'isDirty');
     } else if (dataValue !== cachedValue) {
       isDirty = true;

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -270,6 +270,27 @@ test("should be able to set relationship to null", function() {
   deepEqual(post.toJSON(), {id: 1, author_id: null});
 });
 
+test("materializing the relationship should should not dirty the record", function() {
+  expect(2);
+
+  var Author = Ember.Model.extend({
+        id: Ember.attr()
+      }),
+      Post = Ember.Model.extend({
+        id: Ember.attr(),
+        author: Ember.belongsTo(Author, {key: 'author_id'})
+      });
+
+  Post.adapter = Ember.FixtureAdapter.create();
+  Author.adapter = Ember.FixtureAdapter.create();
+
+  var post = Ember.run(Post, Post.create);
+  post.get('id');
+  ok(!post.get('isDirty'));
+  post.get('author');
+  ok(!post.get('isDirty'));
+});
+
 test("setting relationship should make parent dirty", function() {
   expect(1);
 

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -43,6 +43,25 @@ test("when properties have changed on a model, isDirty should be set", function(
   Ember.run(obj, obj.save);
 });
 
+test("when properties defined in create have not changed on a model, isDirty should be false", function() {
+  expect(3);
+
+  var Model = Ember.Model.extend({
+    name: attr(),
+    city: attr()
+  });
+
+  var obj = Ember.run(Model, Model.create, {name: 'Jeffrey', city: 'SF'});
+  ok(!obj.get('isDirty'));
+
+  obj.set('name', 'Jeffrey');
+  obj.set('city', 'SF');
+  ok(!obj.get('isDirty'));
+
+  obj.set('name', 'Erik');
+  ok(obj.get('isDirty'));
+});
+
 test("when properties are changed back to the loaded value, isDirty should be false", function() {
   expect(6);
 
@@ -219,4 +238,3 @@ test("getting embedded belongsTo attribute after load should not make parent dir
   var author = post.get('author');
   equal(post.get('isDirty'), false, 'get belongsTo relationship does not dirty post record');
 });
-

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -128,3 +128,24 @@ test("toJSON uses the given relationship key", function() {
 
   deepEqual(article.toJSON(), { comment_ids: ['a'] }, "Relationship ids should be serialized only under the given key");
 });
+
+test("materializing the relationship should should not dirty the record", function() {
+  expect(2);
+
+  var Author = Ember.Model.extend({
+        id: Ember.attr()
+      }),
+      Post = Ember.Model.extend({
+        id: Ember.attr(),
+        authors: Ember.hasMany(Author, {key: 'author_ids'})
+      });
+
+  Post.adapter = Ember.FixtureAdapter.create();
+  Author.adapter = Ember.FixtureAdapter.create();
+
+  var post = Ember.run(Post, Post.create);
+  post.get('id');
+  ok(!post.get('isDirty'));
+  post.get('authors');
+  ok(!post.get('isDirty'));
+});


### PR DESCRIPTION
- fix is for `attr` only setting `_data` for the first property set in `create`. This bug manifests itself into an `isDirty` bug, where subsequent properties set in `create` will always be dirty.
- fix when materializing relationships of a newly created record. `isDirty` is true because `dataValue` is `undefined`.
