### PR TITLE
Fix isDirty when relationships were loaded in or set during create

### DIFF
--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -15,6 +15,8 @@ Ember.belongsTo = function(type, options) {
 
   return Ember.computed(function(key, value) {
     type = meta.getType();
+    var data = get(this, '_data'),
+      beingCreated = Ember.meta(this).proto === this;
 
     if (arguments.length === 2) {
       if (value) {
@@ -22,7 +24,15 @@ Ember.belongsTo = function(type, options) {
                      [value.constructor, type]),
                      value instanceof type);
       }
-      return value === undefined ? null : value;  
+      var result = value === undefined ? null : value;
+      if (beingCreated) {
+        if (!data) {
+          data = {};
+          Ember.set(this, '_data', data);
+        }
+        data[this.dataKey(key)] = result;
+      }
+      return result;
     } else {
       return this.getBelongsTo(relationshipKey, type, meta);
     }

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -52,7 +52,7 @@ function extractDirty(object, attrsOrRelations, dirtyAttributes) {
       isDirty = !dataType.isEqual(dataValue, cachedValue);
     } else if (dataValue && cachedValue instanceof Ember.Model) { // belongsTo case
       isDirty = get(cachedValue, 'isDirty');
-    } else if (dataValue === undefined && cachedValue instanceof Ember.ManyArray) { // hasMany case
+    } else if (cachedValue instanceof Ember.ManyArray) { // hasMany case
       isDirty = get(cachedValue, 'isDirty');
     } else if (dataValue !== cachedValue) {
       isDirty = true;

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -270,8 +270,8 @@ test("should be able to set relationship to null", function() {
   deepEqual(post.toJSON(), {id: 1, author_id: null});
 });
 
-test("materializing the relationship should should not dirty the record", function() {
-  expect(2);
+test("materializing the relationship should not dirty the record", function() {
+  expect(4);
 
   var Author = Ember.Model.extend({
         id: Ember.attr()
@@ -289,6 +289,16 @@ test("materializing the relationship should should not dirty the record", functi
   ok(!post.get('isDirty'), 'is not dirty before materializing the relationship');
   post.get('author');
   ok(!post.get('isDirty'), 'is not dirty after materializing the relationship');
+
+  var author = Author.create();
+  Ember.run(function() {
+    author.load(100, {id: 100});
+  });
+
+  var postWithData = Post.create({author: author});
+  ok(!postWithData.get('isDirty'), 'with data is not dirty before materializing the relationship');
+  postWithData.get('author');
+  ok(!postWithData.get('isDirty'), 'with data is not dirty after materializing the relationship');
 });
 
 test("setting relationship should make parent dirty", function() {

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -130,7 +130,7 @@ test("toJSON uses the given relationship key", function() {
 });
 
 test("materializing the relationship should should not dirty the record", function() {
-  expect(2);
+  expect(4);
 
   var Author = Ember.Model.extend({
         id: Ember.attr()
@@ -148,4 +148,11 @@ test("materializing the relationship should should not dirty the record", functi
   ok(!post.get('isDirty'), 'is not dirty before materializing the relationship');
   post.get('authors');
   ok(!post.get('isDirty'), 'is not dirty after materializing the relationship');
+
+  var postWithData = Post.create();
+  postWithData.load(1, {author_ids: [2]});
+  postWithData.get('id');
+  ok(!postWithData.get('isDirty'), 'with data is not dirty before materializing the relationship');
+  postWithData.get('authors');
+  ok(!postWithData.get('isDirty'), 'with data is not dirty after materializing the relationship');
 });


### PR DESCRIPTION
- when hasMany is loaded in, parent should not be dirty
- when belongsTo is set during create, add it to _data so that parent isn't dirty
