### PR TITLE
Moved internal attributes and relationships arrays to object constructor (class vars)

### DIFF
--- a/packages/ember-model/tests/attr_test.js
+++ b/packages/ember-model/tests/attr_test.js
@@ -199,20 +199,3 @@ test("toJSON should respect the key option in attr", function() {
   equal(json.Author, "Guilherme", "json.Author should be Guilherme");
   equal(json.author, undefined, "json.author should be undefined");
 });
-
-test("attributes array should be prepared after defining a model", function() {
-  var Model = Ember.Model.extend({
-    id: attr()
-  });
-
-  var Page = Model.extend({
-    title: attr()
-  });
-
-  var Person = Model.extend({
-    name: attr()
-  });
-
-  deepEqual(Page.create().attributes, ['id', 'title']);
-  deepEqual(Person.create().attributes, ['id', 'name']);
-});

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -394,26 +394,61 @@ test("Model#create() works as expected", function() {
   stop();
 });
 
-test("relationships are added to relationships list", function() {
+test(".getAttributes() returns the model's attributes", function() {
+  var attr = Ember.attr,
+      BaseModel = Ember.Model.extend({
+        id: attr()
+      }),
+
+      Person = BaseModel.extend({
+        name: attr(),
+        nationality: attr()
+      }),
+
+      Employee = Person.extend({
+        employeeId: attr()
+      }),
+
+      Animal = BaseModel.extend({
+        order: attr(),
+        family: attr(),
+        genus: attr(),
+        species: attr()
+      });
+
+  deepEqual(Employee.getAttributes(), ['id', 'name', 'nationality', 'employeeId']);
+  deepEqual(Person.getAttributes(), ['id', 'name', 'nationality']);
+  deepEqual(Animal.getAttributes(), ['id', 'order', 'family', 'genus', 'species']);
+  deepEqual(BaseModel.getAttributes(), ['id']);
+});
+
+test(".getRelationships() returns the model's relationships", function() {
   var Comment = Ember.Model.extend(),
       Rating = Ember.Model.extend(),
       Author = Ember.Model.extend(),
       Site = Ember.Model.extend(),
-      Article = Ember.Model.extend({
+
+      Commentable = Ember.Model.extend({
         comments: Ember.hasMany(Comment, { key: 'comments' }),
+      }),
+
+      Article = Commentable.extend({
         author: Ember.belongsTo(Author, { key: 'author' }),
         ratings: Ember.hasMany(Rating, { key: 'ratings' })
       }),
+
       News = Article.extend({
         source: Ember.belongsTo(Site, { key: 'site' })
       });
 
-  deepEqual(Article.proto().relationships, ['comments', 'author', 'ratings'], 'relationships keys should be saved into relationships attribute');
-  deepEqual(News.proto().relationships, ['comments', 'author', 'ratings', 'source'], 'relationships keys should be saved into relationships attribute');
+  deepEqual(Commentable.getRelationships(), ['comments']);
+  deepEqual(Article.getRelationships(), ['comments', 'author', 'ratings']);
+  deepEqual(News.getRelationships(), ['comments', 'author', 'ratings', 'source']);
 });
 
 test("toJSON includes embedded relationships", function() {
-  var Comment = Ember.Model.extend({
+  var attr = Ember.attr,
+      Comment = Ember.Model.extend({
         id: Ember.attr(),
         text: Ember.attr()
       }),


### PR DESCRIPTION
Previous implementation involving placing of said arrays in object prototype and using slice()  was repeatedly initializing a new array each time an attribute or a relationship is defined.

There is no reason for the internal attributes and relationships arrays to be instance variables, especially now that Ember.Object.create no longer supports defining computed properties.

Also added Model.getAttributes() and Model.getRelationships() methods.
