### PR TITLE
Ensure records loaded after a FilteredRecordArray is created are sent through the filter

### DIFF
--- a/packages/ember-model/lib/filtered_record_array.js
+++ b/packages/ember-model/lib/filtered_record_array.js
@@ -21,6 +21,15 @@ Ember.FilteredRecordArray = Ember.RecordArray.extend({
     this.updateFilter();
   },
 
+  // Semantically it doesn't make much sense to push an object onto a FilteredRecordArray,
+  // but if the record is of the correct type, we can add the observers and apply the filter.
+  pushObject: function(record) {
+    if (record.constructor === get(this, 'modelClass')) {
+      this.registerObserversOnRecord(record);
+      this.updateFilter();
+    }
+  },
+
   updateFilter: function() {
     var self = this,
         results = [];

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -594,6 +594,10 @@ Ember.Model.reopenClass({
       if (sideloadedData) {
         record.load(id, sideloadedData);
       }
+
+      record.one('didLoad', function() {
+        record.constructor.addToRecordArrays(record);
+      });
     }
 
     return record;
@@ -605,12 +609,7 @@ Ember.Model.reopenClass({
     }
     if (this.recordArrays) {
       this.recordArrays.forEach(function(recordArray) {
-        if (recordArray instanceof Ember.FilteredRecordArray) {
-          recordArray.registerObserversOnRecord(record);
-          recordArray.updateFilter();
-        } else {
-          recordArray.pushObject(record);
-        }
+        recordArray.pushObject(record);
       });
     }
   },

--- a/packages/ember-model/tests/filtered_record_array_test.js
+++ b/packages/ember-model/tests/filtered_record_array_test.js
@@ -74,7 +74,27 @@ test("with a filter will return only the relevant loaded records", function() {
   stop();
 });
 
-test("loading a record that doesn't match the filter after creating a FilteredRecordArray shouldn't change the content", function() {
+test("will include relevant records fetched after the filter was created", function() {
+  expect(2);
+
+  var recordArray = Ember.FilteredRecordArray.create({
+    modelClass: Model,
+    filterFunction: function(record) {
+      return record.get('name') === 'Erik';
+    },
+    filterProperties: ['name']
+  });
+
+  Model.fetch().then(function() {
+    start();
+    equal(recordArray.get('length'), 1, "There is 1 record");
+    equal(recordArray.get('firstObject.name'), 'Erik', "The record data matches");
+  });
+
+  stop();
+});
+
+test("creating a record that doesn't match the filter after creating a FilteredRecordArray shouldn't change the content", function() {
   expect(2);
 
   Model.fetch().then(function() {
@@ -98,7 +118,7 @@ test("loading a record that doesn't match the filter after creating a FilteredRe
   stop();
 });
 
-test("loading a record that matches the filter after creating a FilteredRecordArray should update the content of it", function() {
+test("creating a record that matches the filter after creating a FilteredRecordArray should update the content of it", function() {
   expect(3);
 
   Model.fetch().then(function() {


### PR DESCRIPTION
I was finding that if I created a FilteredRecordArray and then subsequently loaded records, they were not being included by the filter as expected.

The fix to the initial problem is to ensure loaded records are added to any record arrays.

While I was poking around I also noticed that Ember.Model was aware of Ember.FilteredRecordArray, so I cleaned that up a bit as well. This can be moved to another PR or dropped altogether without affecting the actual fix.
