### PR TITLE
Fix with horrible hack

### DIFF
--- a/packages/ember-model/lib/attr.js
+++ b/packages/ember-model/lib/attr.js
@@ -75,7 +75,7 @@ Ember.attr = function(type, options) {
         dataValue = data && get(data, dataKey),
         beingCreated = meta(this).proto === this;
 
-    if (arguments.length === 2) {
+    if (arguments.length === 2 && arguments[1] !== 'Ember.Model.revertAttribute!') {
       if (beingCreated) {
         if (!data) {
           data = {};

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -256,7 +256,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
           reverts = {};
       for (var i = 0; i < this._dirtyAttributes.length; i++) {
         var attr = this._dirtyAttributes[i];
-        reverts[attr] = data[attr];
+        reverts[attr] = 'Ember.Model.revertAttribute!';
       }
       setProperties(this, reverts);
     }

--- a/packages/ember-model/tests/attr_test.js
+++ b/packages/ember-model/tests/attr_test.js
@@ -247,3 +247,43 @@ test("attributes array should be prepared after defining a model", function() {
   deepEqual(Page.create().attributes, ['id', 'title']);
   deepEqual(Person.create().attributes, ['id', 'name']);
 });
+
+
+test("custom attributes should revert correctly", function() {
+  var Time = {
+    serialize: function (time) {
+      return time.hour + ":" + time.min;
+    },
+    deserialize: function (string) {
+      var array = string.split(":");
+      return {
+        hour: parseInt(array[0], 10),
+        min: parseInt(array[1], 10)
+      };
+    }
+  };
+
+  var Post = Ember.Model.extend({
+    time: Ember.attr(Time)
+  });
+
+  var post = Post.create({});
+  post.load(1, {time: "10:11"});
+
+  var t0 = post.get('time');
+  equal(t0.hour, 10, "Time should have correct hour");
+  equal(t0.min, 11, "Time should have correct minute");
+
+  post.set('time', { hour: 11, min: 12 });
+
+  var t1 = post.get('time');
+  equal(t1.hour, 11, "Time should have correct hour");
+  equal(t1.min, 12, "Time should have correct minute");
+
+  // Correct: t1 properly deserialized. I.e. t1.hour == 10, t1.min == 12
+
+  post.revert();
+  var t2 = post.get('time');
+  equal(t2.hour, 10, "Time should have correct hour");
+  equal(t2.min, 11, "Time should have correct minute");
+});


### PR DESCRIPTION
Fixes #179 with a hack, could do with a better way of doing it.

Another way would be: make the deserialize function in attr.js public, e.g. Ember.Model.deserialize, that way it can be called from revert method in model. But this breaks encapsulation.

The best way would be if there was a way to invalidate the attr property in revert, e.g. `this.invalidateProperty(attr)`, but I don't think that exists in ember. Could fake it with a made up dependant key on each attr? But that would be equally hacky. @ebryn, any idea how to do this in a non hacky way?
