### PR TITLE
Ability to the clear the record cache

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -615,6 +615,26 @@ Ember.Model.reopenClass({
     }
   },
 
+  unload: function (record) {
+    this.removeFromRecordArrays(record);
+    var primaryKey = record.get(get(this, 'primaryKey'));
+    this.removeFromCache(primaryKey);
+  },
+
+  clearCache: function () {
+    this.recordCache = undefined;
+    this.sideloadedData = undefined;
+  },
+
+  removeFromCache: function (key) {
+    if (this.sideloadedData && this.sideloadedData[key]) {
+      delete this.sideloadedData[key];
+    }
+    if (this.recordCache && this.recordCache[key]) {
+      delete this.recordCache[key];
+    }
+  },
+
   removeFromRecordArrays: function(record) {
     if (this._findAllRecordArray) {
       this._findAllRecordArray.removeObject(record);
@@ -660,8 +680,10 @@ Ember.Model.reopenClass({
   load: function(hashes) {
     if (!this.sideloadedData) { this.sideloadedData = {}; }
     for (var i = 0, l = hashes.length; i < l; i++) {
-      var hash = hashes[i];
-      this.sideloadedData[hash[get(this, 'primaryKey')]] = hash;
+      var hash = hashes[i],
+        primaryKey = hash[get(this, 'primaryKey')];
+      this.removeFromCache(primaryKey);
+      this.sideloadedData[primaryKey] = hash;
     }
   },
 

--- a/packages/ember-model/tests/model_sideloading_test.js
+++ b/packages/ember-model/tests/model_sideloading_test.js
@@ -47,3 +47,40 @@ test("sideloading works with camelized attributes", function() {
   strictEqual(record.get('camelCase'), "Dromedary", "camel cased attributes retained correctly");
 });
 
+test("sideloading clears sideload and record cache", function() {
+  expect(6);
+
+  var Model = Ember.Model.extend({
+    id: attr(),
+    name: attr(),
+    worth: attr()
+  });
+
+  Model.adapter = {
+    find: function(record, id) {
+      ok(false, "Adapter#find shouldn't be called for records with sideloaded data");
+    }
+  };
+
+  Model.load([{id: 1, name: "Erik", worth: 123456789}]);
+
+  var record;
+  Ember.run(function() {
+    record = Model.find(1);
+  });
+
+  ok(record.get('isLoaded'), "Record should be loaded immediately");
+  strictEqual(record.get('id'), 1, "Record ID retained successfully");
+  strictEqual(record.get('name'), "Erik", "Record name retained successfully");
+  strictEqual(record.get('worth'), 123456789, "Record worth retained successfully");
+
+  Model.load([{id: 1, name: "Erik", worth: 987654321}]);
+
+  Ember.run(function() {
+    record = Model.find(1);
+  });
+
+  strictEqual(record.get('name'), "Erik", "Record name retained successfully");
+  strictEqual(record.get('worth'), 987654321, "Record worth retained successfully");
+
+});

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -146,6 +146,45 @@ test(".find(id) called multiple times returns the same object (identity map)", f
   equal(first, second);
 });
 
+test(".unload(model) removes models from caches and subsequent find(id) return new objects", function() {
+  expect(4);
+
+  var first = Ember.run(Model, Model.find, 'a'),
+      second = Ember.run(Model, Model.find, 'a');
+
+  Model.unload(first);
+
+  first.set('token', 'b');
+  ok(first.get('token') === second.get('token'), "record models are the same object");
+
+  second = Ember.run(Model, Model.find, 'a');
+  ok(first.get('token') !== second.get('token'), "records ids are different");
+
+  second.set('token', 'b');
+  ok(first.get('token') === second.get('token'));
+
+  second.set('token', 'c');
+  ok(first.get('token') !== second.get('token'));
+});
+
+test(".clearCache destroys sideloadedData and recordCache", function() {
+  expect(4);
+
+  var first = Ember.run(Model, Model.find, 'a'),
+      second = Ember.run(Model, Model.find, 'a');
+
+  Model.load([{token: 2, name: 'Yehuda'}]);
+
+  ok(Model.recordCache !== undefined);
+  ok(Model.sideloadedData !== undefined);
+
+  Model.clearCache();
+
+  ok(Model.recordCache === undefined);
+  ok(Model.sideloadedData === undefined);
+  
+});
+
 test("new records are added to the identity map", function() {
   expect(2);
 


### PR DESCRIPTION
This is very useful for testing, or if you ever need to blast a record
out of the cache and get a new version of it (for whatever reason or
another)
