### PR TITLE
Ember.Model doesn't need to know about FilteredRecordArray

### DIFF
--- a/packages/ember-model/lib/filtered_record_array.js
+++ b/packages/ember-model/lib/filtered_record_array.js
@@ -21,6 +21,23 @@ Ember.FilteredRecordArray = Ember.RecordArray.extend({
     this.updateFilter();
   },
 
+  // Semantically it doesn't make much sense to push an object onto a
+  // FilteredRecordArray, but if the record is of the correct type, we can add
+  // the observers and apply the filter.
+  pushObject: function(record) {
+    if (record instanceof get(this, 'modelClass')) {
+      this.registerObserversOnRecord(record);
+      this.updateFilter();
+    }
+  },
+
+  removeObject: function(record) {
+    if (record instanceof get(this, 'modelClass')) {
+      this.unregisterObserversOnRecord(record);
+      this.get('content').removeObject(record);
+    }
+  },
+
   updateFilter: function() {
     var self = this,
         results = [];
@@ -52,6 +69,15 @@ Ember.FilteredRecordArray = Ember.RecordArray.extend({
 
     for (var i = 0, l = get(filterProperties, 'length'); i < l; i++) {
       record.addObserver(filterProperties[i], self, 'updateFilterForRecord');
+    }
+  },
+
+  unregisterObserversOnRecord: function(record) {
+    var self = this,
+        filterProperties = get(this, 'filterProperties');
+
+    for (var i = 0, l = get(filterProperties, 'length'); i < l; i++) {
+      record.removeObserver(filterProperties[i], self, 'updateFilterForRecord');
     }
   }
 });

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -623,12 +623,7 @@ Ember.Model.reopenClass({
     }
     if (this.recordArrays) {
       this.recordArrays.forEach(function(recordArray) {
-        if (recordArray instanceof Ember.FilteredRecordArray) {
-          recordArray.registerObserversOnRecord(record);
-          recordArray.updateFilter();
-        } else {
-          recordArray.pushObject(record);
-        }
+        recordArray.pushObject(record);
       });
     }
   },

--- a/packages/ember-model/tests/filtered_record_array_test.js
+++ b/packages/ember-model/tests/filtered_record_array_test.js
@@ -123,6 +123,31 @@ test("loading a record that matches the filter after creating a FilteredRecordAr
   stop();
 });
 
+test("unloading a record that matches the filter should remove the record from the FilteredRecordArray", function() {
+  expect(4);
+
+  Model.fetch().then(function() {
+    start();
+
+    var recordArray = Ember.FilteredRecordArray.create({
+      modelClass: Model,
+      filterFunction: function(record) {
+        return record.get('name') === 'Erik';
+      },
+      filterProperties: ['name']
+    });
+
+    equal(recordArray.get('length'), 1, "There is 1 record");
+    var model = recordArray.get('firstObject');
+    equal(Ember.observersFor(model, 'name').length, 1, "There is 1 name observer");
+    Model.unload(model);
+    equal(recordArray.get('length'), 0, "There are 0 records");
+    equal(Ember.observersFor(model, 'name').length, 0, "There are 0 name observers");
+  });
+
+  stop();
+});
+
 test("changing a property that matches the filter should update the FilteredRecordArray to include it", function() {
   expect(5);
   Model.fetch().then(function() {


### PR DESCRIPTION
Updated PR to replace #209. Added FilteredRecordArray#removeObject() to clean up the observers.

There was a question of whether pushObject() should raise an exception if the supplied record is not of the correct type. To my thinking this is no different than if the model is of the correct type but the filter does not match - ie. the client calls pushObject() and the supplied object is not added to the FilteredRecordArray.
