### PR TITLE
Remove cached records if findAll promise is rejected

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -437,6 +437,14 @@ Ember.Model.reopenClass({
 
     var promise = this.adapter.findAll(this, records);
 
+    // Remove the cached record array if the promise is rejected
+    if (promise.then) {
+      promise.then(null, function() {
+        self._findAllRecordArray = null;
+        return Ember.RSVP.reject.apply(null, arguments);
+      });
+    }
+
     return isFetch ? promise : records;
   },
 

--- a/packages/ember-model/tests/adapter/find_all_test.js
+++ b/packages/ember-model/tests/adapter/find_all_test.js
@@ -27,7 +27,7 @@ test("Model.find() delegates to Adapter#findAll", function() {
   });
 });
 
-test("Model.find() always returns the same RecordArray", function() {
+test("Model.find() returns the same RecordArray for each successful call", function() {
   var Model = Ember.Model.extend();
   Model.adapter = {
     findAll: Ember.K
@@ -37,4 +37,19 @@ test("Model.find() always returns the same RecordArray", function() {
   var secondResult = Model.find();
 
   equal(firstResult, secondResult, "The same RecordArray was returned");
+});
+
+test("Model.find() returns a new RecordArray if the last call failed", function() {
+  var Model = Ember.Model.extend();
+  Model.adapter = {
+    findAll: Ember.RSVP.reject
+  };
+
+  var firstResult, secondResult;
+  Ember.run(function() {
+    firstResult = Model.find();
+  });
+  secondResult = Model.find();
+
+  notEqual(firstResult, secondResult, "A new RecordArray was returned");
 });


### PR DESCRIPTION
Here's my attempt at fixing #189 so an empty RecordArray isn't returned after retrying a failed findAll.
