### PR TITLE
Cached belongsTo records that arrive embedded

### DIFF
--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -61,6 +61,10 @@ Ember.Model.reopen({
       var primaryKey = get(type, 'primaryKey');
       record = type.create({ isLoaded: false });
       record.load(idOrAttrs[primaryKey], idOrAttrs);
+
+      // store this model in the cache
+      if (!type.recordCache) { type.recordCache = {}; }
+      type.recordCache[idOrAttrs[primaryKey]] = record;
     } else {
       record = type.find(idOrAttrs);
     }


### PR DESCRIPTION
Ran into an issue where attempts to later reload a belongsTo that initial arrived embedded resulting a brand new record
