### PR TITLE
remove references when clearing cache

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -612,6 +612,7 @@ Ember.Model.reopenClass({
   clearCache: function () {
     this.recordCache = undefined;
     this.sideloadedData = undefined;
+    this._idToReference = undefined;
   },
 
   removeFromCache: function (key) {
@@ -620,6 +621,9 @@ Ember.Model.reopenClass({
     }
     if (this.recordCache && this.recordCache[key]) {
       delete this.recordCache[key];
+    }
+    if(this._idToReference && this._idToReference[key]) {
+      delete this._idToReference[key];
     }
   },
 

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -426,3 +426,51 @@ test("belongsTo from an embedded source is able to materialize without having to
   var post1 = project1.get('posts.firstObject');
   equal(project1, post1.get('project'));
 });
+
+
+test("unloaded records are removed from reference cache", function() {
+
+
+  var Company = Ember.Company = Ember.Model.extend({
+     id: Ember.attr('string'),
+     title: Ember.attr('string'),
+     projects: Ember.hasMany('Ember.Project', {key:'projects', embedded: true})
+  }),
+    Project = Ember.Project = Ember.Model.extend({
+        id: Ember.attr('string'),
+        title: Ember.attr('string'),
+        company: Ember.belongsTo('Ember.Company', {key:'company'})
+    });
+
+  var compJson = {
+    id:1,
+    title:'coolio',
+    projects:[{ id: 1, title: 'project one title', company: 1 },
+              { id: 2, title: 'project two title', company: 1 }]  
+    }, compJson2 = {
+    id:1,
+    title:'coolio',
+    projects:[{ id: 1, title: 'project one new title', company: 1 },
+              { id: 2, title: 'project two new title', company: 1 }]  
+    };
+
+  Company.load([compJson]);
+  var company = Company.find(1);
+  var project1 = company.get('projects.firstObject');
+
+  equal(company.get('projects.length'), 2);
+
+  Company.unload(company);
+  company.get('projects').forEach(function(project){
+   Project.unload(project);
+  });
+
+  Company.load([compJson2]);
+  company = Company.find(1);
+  var reloadedProject1 = company.get('projects.firstObject');
+
+
+  notEqual(project1, reloadedProject1);
+  equal(project1.get('title'), 'project one title');
+  equal(reloadedProject1.get('title'), 'project one new title');
+});


### PR DESCRIPTION
I didn't realize the references were keeping track of records as well.  This in turn leads to stale data in hasMany collections when they attempt to reload ids which were cleared out etc.
