### PR TITLE
Merging the recordCache with the referenceCache

### DIFF
--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -58,9 +58,10 @@ Ember.Model.reopen({
     }
 
     if (meta.options.embedded) {
-      var primaryKey = get(type, 'primaryKey');
-      record = type.create({ isLoaded: false });
-      record.load(idOrAttrs[primaryKey], idOrAttrs);
+      var primaryKey = get(type, 'primaryKey'),
+        id = idOrAttrs[primaryKey];
+      record = type.create({ isLoaded: false, id: id });
+      record.load(id, idOrAttrs);
     } else {
       record = type.find(idOrAttrs);
     }

--- a/packages/ember-model/lib/has_many.js
+++ b/packages/ember-model/lib/has_many.js
@@ -30,7 +30,6 @@ Ember.Model.reopen({
     });
 
     this._registerHasManyArray(collection);
-    if (embedded) type.pushIntoRecordCache(collection);
 
     return collection;
   }

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -87,7 +87,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
         id = this.getPrimaryKey();
 
     if (!reference) {
-      reference = this.constructor._referenceForId(id);
+      reference = this.constructor._getOrCreateReferenceForId(id);
       reference.record = this;
       this._reference = reference;
     }
@@ -229,9 +229,6 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
 
     set(this, 'isNew', false);
 
-    if (!this.constructor.recordCache) this.constructor.recordCache = {};
-    this.constructor.recordCache[id] = this;
-
     this._copyDirtyAttributesToData();
     this.constructor.addToRecordArrays(this);
     this.trigger('didCreateRecord');
@@ -305,12 +302,12 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
       if (embedded) {
         primaryKey = get(type, 'primaryKey');
         mapFunction = function(attrs) {
-          reference = type._referenceForId(attrs[primaryKey]);
+          reference = type._getOrCreateReferenceForId(attrs[primaryKey]);
           reference.data = attrs;
           return reference;
         };
       } else {
-        mapFunction = function(id) { return type._referenceForId(id); };
+        mapFunction = function(id) { return type._getOrCreateReferenceForId(id); };
       }
       content = Ember.EnumerableUtils.map(content, mapFunction);
     }
@@ -568,29 +565,20 @@ Ember.Model.reopenClass({
     });
   },
 
-  pushIntoRecordCache: function(records){
-    var primaryKey = get(this, 'primaryKey'), self = this;
-    if (!this.recordCache) this.recordCache = {};
-
-    records.forEach(function(record){
-      self.recordCache[get(record, primaryKey)] = record;
-    });
-  },
-
-  getFromRecordCache: function(id){
-    if (!this.recordCache) this.recordCache = {};
-    return this.recordCache[id];
+  getCachedReferenceRecord: function(id){
+    var ref = this._getReferenceById(id);
+    if(ref) return ref.record;
+    return undefined;
   },
 
   cachedRecordForId: function(id) {
-    var record = this.getFromRecordCache(id);
+    var record = this.getCachedReferenceRecord(id);
 
     if (!record) {
       var primaryKey = get(this, 'primaryKey'),
         attrs = {isLoaded: false};
       attrs[primaryKey] = id;
       record = this.create(attrs);
-      this.pushIntoRecordCache([record]);
       var sideloadedData = this.sideloadedData && this.sideloadedData[id];
       if (sideloadedData) {
         record.load(id, sideloadedData);
@@ -624,20 +612,16 @@ Ember.Model.reopenClass({
   },
 
   clearCache: function () {
-    this.recordCache = undefined;
     this.sideloadedData = undefined;
-    this._idToReference = undefined;
+    this._referenceCache = undefined;
   },
 
   removeFromCache: function (key) {
     if (this.sideloadedData && this.sideloadedData[key]) {
       delete this.sideloadedData[key];
     }
-    if (this.recordCache && this.recordCache[key]) {
-      delete this.recordCache[key];
-    }
-    if(this._idToReference && this._idToReference[key]) {
-      delete this._idToReference[key];
+    if(this._referenceCache && this._referenceCache[key]) {
+      delete this._referenceCache[key];
     }
   },
 
@@ -676,10 +660,9 @@ Ember.Model.reopenClass({
   },
 
   forEachCachedRecord: function(callback) {
-    if (!this.recordCache) { return Ember.A([]); }
-    var ids = Object.keys(this.recordCache);
+    var ids = Object.keys(this._referenceCache);
     ids.map(function(id) {
-      return this.recordCache[id];
+      return this._getReferenceById(id).record;
     }, this).forEach(callback);
   },
 
@@ -693,10 +676,14 @@ Ember.Model.reopenClass({
     }
   },
 
-  _referenceForId: function(id) {
-    if (!this._idToReference) { this._idToReference = {}; }
+  _getReferenceById: function(id) {
+    if (!this._referenceCache) { this._referenceCache = {}; }
+    return this._referenceCache[id];
+  },
 
-    var reference = this._idToReference[id];
+  _getOrCreateReferenceForId: function(id) {
+    var reference = this._getReferenceById(id);
+
     if (!reference) {
       reference = this._createReference(id);
     }
@@ -705,9 +692,9 @@ Ember.Model.reopenClass({
   },
 
   _createReference: function(id) {
-    if (!this._idToReference) { this._idToReference = {}; }
+    if (!this._referenceCache) { this._referenceCache = {}; }
 
-    Ember.assert('The id ' + id + ' has alread been used with another record of type ' + this.toString() + '.', !id || !this._idToReference[id]);
+    Ember.assert('The id ' + id + ' has alread been used with another record of type ' + this.toString() + '.', !id || !this._referenceCache[id]);
 
     var reference = {
       id: id,
@@ -717,7 +704,7 @@ Ember.Model.reopenClass({
     // if we're creating an item, this process will be done
     // later, once the object has been persisted.
     if (id) {
-      this._idToReference[id] = reference;
+      this._referenceCache[id] = reference;
     }
 
     return reference;

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -474,3 +474,41 @@ test("unloaded records are removed from reference cache", function() {
   equal(project1.get('title'), 'project one title');
   equal(reloadedProject1.get('title'), 'project one new title');
 });
+
+test("belongsTo records created are available from reference cache", function() {
+
+
+  var Company = Ember.Company = Ember.Model.extend({
+     id: Ember.attr('string'),
+     title: Ember.attr('string'),
+     project: Ember.belongsTo('Ember.Project', {key:'project', embedded: true})
+  }),
+    Project = Ember.Project = Ember.Model.extend({
+        id: Ember.attr('string'),
+        title: Ember.attr('string'),
+        company: Ember.belongsTo('Ember.Company', {key:'company'})
+    });
+
+  var compJson = {
+    id:1,
+    title:'coolio',
+    project:{
+          id: 1,
+          title: 'project one title',
+          company: 1 
+      }
+    };
+
+  Company.load([compJson]);
+  var company = Company.find(1);
+
+  var project = company.get('project');
+  var projectFromCacheViaFind = Project.find(project.get('id'));
+  var projectRecordFromCache = Project._referenceCache[project.get('id')].record;
+
+  equal(project, projectFromCacheViaFind);
+  equal(project, projectRecordFromCache);
+
+  // referenced company record is the same as the company returned from find
+  equal(company, project.get('company'));
+});

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -167,7 +167,7 @@ test(".unload(model) removes models from caches and subsequent find(id) return n
   ok(first.get('token') !== second.get('token'));
 });
 
-test(".clearCache destroys sideloadedData and recordCache", function() {
+test(".clearCache destroys sideloadedData and record references", function() {
   expect(4);
 
   var first = Ember.run(Model, Model.find, 'a'),
@@ -175,12 +175,12 @@ test(".clearCache destroys sideloadedData and recordCache", function() {
 
   Model.load([{token: 2, name: 'Yehuda'}]);
 
-  ok(Model.recordCache !== undefined);
+  ok(Model._referenceCache !== undefined);
   ok(Model.sideloadedData !== undefined);
 
   Model.clearCache();
 
-  ok(Model.recordCache === undefined);
+  ok(Model._referenceCache === undefined);
   ok(Model.sideloadedData === undefined);
   
 });
@@ -196,8 +196,8 @@ test("new records are added to the identity map", function() {
   record.on("didCreateRecord", function() {
     start();
 
-    ok(Model.recordCache);
-    equal(Model.recordCache[2], record);
+    ok(Model._referenceCache);
+    equal(Model._referenceCache[2].record, record);
   });
 });
 
@@ -565,11 +565,11 @@ test("can use data as attribute name", function() {
   deepEqual(record.toJSON(), {id: 1, data: 'abc'});
 });
 
-test("record is available in record cache when load is run in cachedRecordForId", function() {
+test("record is available in reference cache when load is run in cachedRecordForId", function() {
   var recordFromCache,
       Post = Ember.Model.extend({
         load: function() {
-          recordFromCache = this.constructor.recordCache['1'];
+          recordFromCache = this.constructor._referenceCache['1'].record;
         }
       });
 
@@ -577,7 +577,7 @@ test("record is available in record cache when load is run in cachedRecordForId"
 
   Post.cachedRecordForId('1');
 
-  ok(recordFromCache, 'record should be available in recordCache when running load');
+  ok(recordFromCache, 'record should be available in cache when running load');
 });
 
 test("fetchQuery returns a promise", function() {


### PR DESCRIPTION
Everytime a record is created with an id, it's automatically added to the referenceCache.  We also only keep one cache of records now, instead of two places.  Records loaded from hasMany or belongsTo will also be available in the cache, and will be accessible from a find call etc.
