### PR TITLE
Fixed FilteredRecordArray adding records multiple times when updating matching record properties

### DIFF
--- a/packages/ember-model/lib/filtered_record_array.js
+++ b/packages/ember-model/lib/filtered_record_array.js
@@ -34,7 +34,7 @@ Ember.FilteredRecordArray = Ember.RecordArray.extend({
 
   updateFilterForRecord: function(record) {
     var results = get(this, 'content');
-    if (this.filterFunction(record)) {
+    if (this.filterFunction(record) && !results.contains(record)) {
       results.pushObject(record);
     }
   },

--- a/packages/ember-model/tests/filtered_record_array_test.js
+++ b/packages/ember-model/tests/filtered_record_array_test.js
@@ -153,7 +153,7 @@ test("changing a property that matches the filter should update the FilteredReco
 });
 
 test("adding a new record and changing a property that matches the filter should update the FilteredRecordArray to include it", function() {
-  expect(5);
+  expect(8);
 
   Model.fetch().then(function() {
     start();
@@ -175,6 +175,12 @@ test("adding a new record and changing a property that matches the filter should
       equal(recordArray.get('length'), 2, "There are 2 records after changing the name");
       equal(recordArray.get('firstObject.name'), 'Erik', "The record data matches");
       equal(recordArray.get('lastObject.name'), 'Ekris', "The record data matches");
+
+      record.set('name', 'Eskil');
+
+      equal(recordArray.get('length'), 2, "There are still 2 records after changing the name again");
+      equal(recordArray.get('firstObject.name'), 'Erik', "The record data still matches");
+      equal(recordArray.get('lastObject.name'), 'Eskil', "The record data still matches");
     });
     stop();
   });


### PR DESCRIPTION
Added both additional assertions to the tests and a quick fix. 

I guess an alternate solution to this would be to use Ember.Set to store the records; unsure of whether there are any performance implications in that case. 
