### PR TITLE
belongsTo/embed/sideload change

### DIFF
--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -60,7 +60,10 @@ Ember.Model.reopen({
     if (meta.options.embedded) {
       var primaryKey = get(type, 'primaryKey'),
         id = idOrAttrs[primaryKey];
-      record = type.create({ isLoaded: false, id: id });
+      record = type.getCachedReferenceRecord(id);
+      if(!record){
+        record = type.create({ isLoaded: false, id: id });
+      }
       record.load(id, idOrAttrs);
     } else {
       record = type.find(idOrAttrs);

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -512,3 +512,32 @@ test("belongsTo records created are available from reference cache", function() 
   // referenced company record is the same as the company returned from find
   equal(company, project.get('company'));
 });
+
+
+test("belongsTo of existing record doesn't create a new record", function() {
+  var childById = {id:1, age:0},
+      modelByIdResponse = {id:1, age:1, child:{id:1, age:1}};
+
+  var ChildModel = Ember.Model.extend({
+    age: Ember.attr()
+  });
+
+  var Model = Ember.Model.extend({
+    age: Ember.attr(),
+    child: Ember.belongsTo(ChildModel, { key: 'child', embedded: true})
+  });
+
+  ChildModel.load(childById);
+  var child = ChildModel.find(1);
+
+  equal(child.get('age'), 0, "original age is correct");
+
+  Model.load(modelByIdResponse);
+
+  equal(child.get('age'), 1, "The age is updated to reflect the new information from an embedded source after sideload");
+
+  var model1 = Model.find(1);
+  equal(model1.get('child'), child, "The record is the same");
+  equal(model1.get('child.age'), 1, "The correct age is returned");
+});
+

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -167,8 +167,8 @@ test(".unload(model) removes models from caches and subsequent find(id) return n
   ok(first.get('token') !== second.get('token'));
 });
 
-test(".clearCache destroys sideloadedData and record references", function() {
-  expect(4);
+test(".clearCache destroys record references", function() {
+  expect(2);
 
   var first = Ember.run(Model, Model.find, 'a'),
       second = Ember.run(Model, Model.find, 'a');
@@ -176,12 +176,10 @@ test(".clearCache destroys sideloadedData and record references", function() {
   Model.load([{token: 2, name: 'Yehuda'}]);
 
   ok(Model._referenceCache !== undefined);
-  ok(Model.sideloadedData !== undefined);
 
   Model.clearCache();
 
   ok(Model._referenceCache === undefined);
-  ok(Model.sideloadedData === undefined);
   
 });
 
@@ -573,7 +571,8 @@ test("record is available in reference cache when load is run in cachedRecordFor
         }
       });
 
-  Post.sideloadedData = { '1': { id: '1' } };
+  // sideload data
+  Post.load({ id: '1' });
 
   Post.cachedRecordForId('1');
 


### PR DESCRIPTION
belongsTo now uses pre-existing record if it's an embedded source

embedded records that are loaded will also be propogated (even if the
parent record doesn't exist in the system)

removed sideload cache object since it's no longer necessary.  all
of the records live in the reference cache
