### PR TITLE
allows custom `settings` for rest adapter's _ajax

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -115,7 +115,7 @@ Ember.RESTAdapter = Ember.Adapter.extend({
       return urlRoot + ".json";
     }
   },
-  
+
   ajaxSettings: function(url, method) {
     return {
       url: url,
@@ -124,8 +124,10 @@ Ember.RESTAdapter = Ember.Adapter.extend({
     };
   },
 
-  _ajax: function(url, params, method) {
-    var settings = this.ajaxSettings(url, method);
+  _ajax: function(url, params, method, settings) {
+    if (!settings) {
+      settings = this.ajaxSettings(url, method);
+    }
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
       if (params) {
@@ -146,7 +148,7 @@ Ember.RESTAdapter = Ember.Adapter.extend({
         if (jqXHR) {
           jqXHR.then = null;
         }
-        
+
         Ember.run(null, reject, jqXHR);
       };
 


### PR DESCRIPTION
This PR replaces the hard-coded computation of `ajaxSettings()` with a function parameter, allowing userland code to control the `settings` object passed to the rest adapter's `_ajax()` method.

The corresponding method signature of both `ember-data` and `epf`

``` javascript
ajax(url, method, settings)
```

allows userland code to manipulate the `settings` directly, while that of `ember-model`, before this PR

``` javascript
_ajax(url, params, method)
```

confines userland access to the data / params object.

One use case is to pass in extra headers.

This PR would allow [`ember-auth`](http://ember-auth.herokuapp.com/) to integrate with `ember-model` better.

The corresponding `ember-data` integration, for example, can be done in `ember-auth` like

``` coffeescript
DS.RESTAdapter.reopen
  ajax: (url, type, settings) ->
    super url, type, self.auth._strategy.serialize(settings || {})
```

thus preserving any `ember-data`-specific logic in its own `ajax` hook.

This is not possible for `ember-model`, before this PR, because there is no way to override the local `settings` variable

``` javascript
var settings = this.ajaxSettings(url, method);
```

No BC break is introduced. The method signature is changed to

``` javascript
_ajax(url, params, method, settings)
```

falling back to `settings = this.ajaxSettings(url, method);` when the four argument is absent.

A cleaner solution would be merging the `params` and `settings` arguments together though, producing a signature like that of `ember-data` or `epf`. That, however, would break existing codes.
