### PR TITLE
Updates reference and referenceCache when model primary key changes.

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -90,6 +90,9 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
       reference = this.constructor._getOrCreateReferenceForId(id);
       reference.record = this;
       this._reference = reference;
+    } else if (reference.id !== id) {
+      reference.id = id;
+      this.constructor._cacheReference(reference);
     }
 
     if (!reference.id) {
@@ -731,12 +734,16 @@ Ember.Model.reopenClass({
       clientId: this._clientIdCounter++
     };
 
-    // if we're creating an item, this process will be done
-    // later, once the object has been persisted.
-    if (id) {
-      this._referenceCache[id] = reference;
-    }
+    this._cacheReference(reference);
 
     return reference;
+  },
+
+  _cacheReference: function(reference) {
+    // if we're creating an item, this process will be done
+    // later, once the object has been persisted.
+    if (reference.id) {
+      this._referenceCache[reference.id] = reference;
+    }
   }
 });

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -37,6 +37,25 @@ test("creates reference when creating record", function() {
   equal(reference.record, model, "reference should keep a reference to a model");
 });
 
+test("updates reference and cache when primary key changes", function() {
+  expect(7);
+
+  var model = Model.create(),
+      reference = model._reference;
+
+  equal(reference.id, undefined, "reference should keep record's id");
+  equal(reference.record, model, "reference should keep a reference to a model");
+
+  model.load('abc123', { token: 'abc123', name: 'Joy' });
+  reference = model._reference;
+
+  equal(reference.id, 'abc123', "reference should be updated to record's id");
+  equal(reference.record, model, "reference should keep a reference to a model");
+  equal(reference.record.get('token'), 'abc123', "reference should have updated record's property");
+  equal(reference.record.get('name'), 'Joy', "reference should have updated record's property");
+  equal(Model.find('abc123'), model, 'find should get model');
+});
+
 test("can define attributes with Ember.attr, data is accessible", function() {
   var instance = Model.create({name: "Erik"});
 


### PR DESCRIPTION
1. Model.create will create a reference with the current primary key (in my use case, this is undefined because the primary key is set by the server on POST).
2. The response from the POST is then loaded into the model (now with primary key defined). CreateReference should be updated with the new attributes and the referenceCache should add an entry for this primary key, so Ember.Model.find can find the record later.

Thanks!
