### PR TITLE
update ajax() signature to match _ajax()

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -101,8 +101,8 @@ Ember.RESTAdapter = Ember.Adapter.extend({
     record.didDeleteRecord();
   },
 
-  ajax: function(url, params, method) {
-    return this._ajax(url, params, method || "GET");
+  ajax: function(url, params, method, settings) {
+    return this._ajax(url, params, (method || "GET"), settings);
   },
 
   buildURL: function(klass, id) {


### PR DESCRIPTION
This is a follow-up on #241: since we changed the signature of `_ajax()` method, the corresponding alias/helper `ajax()` should be updated too.
