### PR TITLE
Karen/dirty tracking attrs

### DIFF
--- a/packages/ember-model/lib/attr.js
+++ b/packages/ember-model/lib/attr.js
@@ -41,6 +41,15 @@ function deserialize(value, type) {
   }
 }
 
+function serialize(value, type) {
+  if (type && type.serialize) {
+    return type.serialize(value);
+  } else if (type && Ember.Model.dataTypes[type]) {
+    return Ember.Model.dataTypes[type].serialize(value);
+  } else {
+    return value;
+  }
+}
 
 Ember.attr = function(type, options) {
   return Ember.computed(function(key, value) {
@@ -65,7 +74,7 @@ Ember.attr = function(type, options) {
         dataValue = data[dataKey] = value;
       }
 
-      if (dataValue !== value) {
+      if (dataValue !== serialize(value, type)) {
         dirtyAttributes.pushObject(key);
       } else {
         dirtyAttributes.removeObject(key);

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -149,6 +149,12 @@ test("dirty checking works with date attributes", function() {
 
   deepEqual(obj.get('createdAt'), originalDate);
   ok(!obj.get('isDirty'));
+
+  obj.set('createdAt', new Date(2013, 10, 2));
+  ok(obj.get('isDirty'), "changing a Date attribute makes the record dirty");
+
+  obj.set('createdAt', originalDate);
+  ok(!obj.get('isDirty'), "changing a Date attribute back to original value makes the record clean");
 });
 
 test("getting embedded belongsTo attribute after load should not make parent dirty", function() {


### PR DESCRIPTION
We want models with custom attrs to be marked clean if their values are set back to the original value. Thoughts?

cc @forumm
