### PR TITLE
Update ember-model's id after creating new record

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -69,6 +69,7 @@ Ember.RESTAdapter = Ember.Adapter.extend({
         primaryKey = get(record.constructor, 'primaryKey'),
         dataToLoad = rootKey ? data[rootKey] : data;
     record.load(dataToLoad[primaryKey], dataToLoad);
+    record.set('id', dataToLoad[primaryKey]);
     record.didCreateRecord();
   },
 


### PR DESCRIPTION
Currently ember-model does not update the model with data returned from server. This updates the model's id, ensuring newly-created objects' sub-route is not broken after save().
