### PR TITLE
Removes deleted children when reloading parent with embedded children.

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -303,7 +303,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
       var array = this._hasManyArrays[i],
           hasManyContent = this._getHasManyContent(get(array, 'key'), get(array, 'modelClass'), get(array, 'embedded'));
         for (j = 0; j < array.get('length'); j++) {
-          if (array.objectAt(j).get('isNew')) {
+          if (array.objectAt(j).get('isNew') && !array.objectAt(j).get('isDeleted')) {
             hasManyContent.addObject(array.objectAt(j)._reference);
           }
         }

--- a/packages/ember-model/tests/has_many/embedded_objects_load_test.js
+++ b/packages/ember-model/tests/has_many/embedded_objects_load_test.js
@@ -75,3 +75,43 @@ test("loading embedded data into a parent updates the child records", function()
 
   equal(comment.get('body'), 'new');
 });
+
+test("loading embedded data into a parent with deleted children deletes the children", function() {
+  expect(2);
+
+  var Comment = Ember.Model.extend({
+    id: attr(),
+    body: attr()
+  });
+
+  var Post = Ember.Model.extend({
+    id: attr(),
+    comments: Ember.hasMany(Comment, {key: 'comments', embedded: true})
+  });
+
+  Post.adapter = {
+    find: function(record, id) {
+      record.load(id, {comments: []});
+    }
+  };
+
+  var post = Post.find(1);
+  var comment = Comment.create();
+  post.get('comments').pushObject(comment);
+
+  var json = {
+    id: 1,
+    comments: [
+      {id: 1, body: 'new'}
+    ]
+  };
+
+  // deletes all children and load new ones.
+  post.get('comments').forEach(function(comment) {
+    comment.didDeleteRecord();
+  });
+  post.load(1, json);
+
+  equal(post.get('comments.length'), 1);
+  equal(post.get('comments.firstObject.body'), 'new');
+});


### PR DESCRIPTION
We have an model that has embedded children. Whenever we update that model, the server will delete all the children and create new ones, returning the new children in the response hash.

On the client, we want to mark the embedded children as deleted, and when we load the server response back into the model, the new children in the response should replace the old deleted children.
