### PR TITLE
Reset ManyArray#originalContent when loading or reverting a model.

### DIFF
--- a/packages/ember-model/lib/has_many_array.js
+++ b/packages/ember-model/lib/has_many_array.js
@@ -76,6 +76,13 @@ Ember.ManyArray = Ember.RecordArray.extend({
     }
   },
 
+  load: function(content) {
+    Ember.setProperties(this, {
+      content: content,
+      originalContent: content.slice()
+    });
+  },
+
   _setupOriginalContent: function(content) {
     content = content || get(this, 'content');
     if (content) {

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -307,7 +307,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
             hasManyContent.addObject(array.objectAt(j)._reference);
           }
         }
-      set(array, 'content', hasManyContent);
+      array.load(hasManyContent);
     }
   },
 

--- a/packages/ember-model/tests/has_many/manipulation_test.js
+++ b/packages/ember-model/tests/has_many/manipulation_test.js
@@ -77,4 +77,8 @@ test("removing a record from the many array", function() {
   equal(comments.get('length'), 2, "There are now only two items in the array");
   equal(comments.objectAt(0).get('id'), 1, "The first element is correct");
   equal(comments.objectAt(1).get('id'), 3, "The second element is correct");
+
+  article.revert();
+
+  equal(article.get('isDirty'), false, "article should not be dirty after revert");
 });


### PR DESCRIPTION
Fixing the dirty tracking for models with hasMany relationships.

Currently, calling `revert` on a model with a hasMany relationship triggers `content` observers on the ManyArray, replacing its `originalContent` with dirty content.

cc @karenliu1
