### PR TITLE
add support for setting a defaultValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ var Post = Ember.Model.extend({
   time: attr(Time)
 });
 ```
+### Default values
+
+Attributes can have a default value.
+```javascript
+App.Post = Ember.Model.extend({
+  tags: attr(Array,{defaultValue:[]})
+});
+```
 
 ## Relationships
 

--- a/packages/ember-model/lib/attr.js
+++ b/packages/ember-model/lib/attr.js
@@ -87,6 +87,10 @@ Ember.attr = function(type, options) {
       return value;
     }
 
+    if (dataValue==null && options && options.defaultValue!=null) {
+      return Ember.copy(options.defaultValue);
+    }
+
     return this.getAttr(key, deserialize(dataValue, type));
   }).property('_data').meta({isAttribute: true, type: type, options: options});
 };

--- a/packages/ember-model/tests/attr_test.js
+++ b/packages/ember-model/tests/attr_test.js
@@ -244,3 +244,27 @@ test("custom attributes should revert correctly", function () {
   // should not be dirty now
   ok(post.get('isDirty') === false, "model should no longer be dirty after reverting changes");
 });
+
+test("attr should handle default values", function() {
+  var Book = Ember.Model.extend({
+    author: attr(String, { defaultValue: 'anonymous'}),
+    chapters: attr(String, { defaultValue: []})
+  });
+  var novel = Book.create();
+  var coloringBook = Book.create();
+
+  Ember.run(function() {
+    novel.load(1, { author: "Jane" });
+    coloringBook.load(1, { });
+  });
+  novel.get("chapters").push('intro');
+
+  equal(novel.get('author'), "Jane", "author should be Jane");
+  equal(coloringBook.get('author'), "anonymous", "missing author should be filled in");
+  deepEqual(novel.get('chapters'), ['intro'], "mutable defaults should be filled in");
+  deepEqual(coloringBook.get('chapters'), [], "mutable defaults should not be shared");
+
+  var json = coloringBook.toJSON();
+  equal(json.author, "anonymous", "default values should be serialized");
+  deepEqual(json.chapters, [], "default values should be serialized");
+});


### PR DESCRIPTION
This lets you set a default value for attributes in ember model as suggested in #270. I'm a little worried that it is only a four line change. It seems to work for me, but the API I am talking to is currently read-only.
