### PR TITLE
Set dirtyAttributes when setting belongs-to to value is falsy

### DIFF
--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -26,21 +26,23 @@ Ember.belongsTo = function(type, options) {
     }
 
     if (arguments.length > 1) {
+
       if (value) {
         Ember.assert(Ember.String.fmt('Attempted to set property of type: %@ with a value of type: %@',
-                     [value.constructor, type]),
-                     value instanceof type);
-
-        if (oldValue !== value) {
-          dirtyAttributes.pushObject(key);
-        } else {
-          dirtyAttributes.removeObject(key);
-        }
-
-        if (createdDirtyAttributes) {
-          set(this, '_dirtyAttributes', dirtyAttributes);
-        }
+                    [value.constructor, type]),
+                    value instanceof type);
       }
+
+      if (oldValue !== value) {
+        dirtyAttributes.pushObject(key);
+      } else {
+        dirtyAttributes.removeObject(key);
+      }
+
+      if (createdDirtyAttributes) {
+        set(this, '_dirtyAttributes', dirtyAttributes);
+      }
+
       return value === undefined ? null : value;  
     } else {
       return this.getBelongsTo(relationshipKey, type, meta);

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -353,6 +353,38 @@ test("setting existing nonembedded relationship should make parent dirty", funct
   ok(post.get('isDirty'));
 });
 
+test("setting existing nonembedded relationship to NULL should make parent dirty", function() {
+  expect(1);
+
+  var Author = Ember.Model.extend({
+        id: Ember.attr(),
+        name: Ember.attr()
+      }),
+      Post = Ember.Model.extend({
+        id: Ember.attr(),
+        author: Ember.belongsTo(Author, {key: 'author_id'})
+      });
+
+  Post.adapter = Ember.FixtureAdapter.create();
+  Author.adapter = Ember.FixtureAdapter.create();
+
+  var post = Post.create(),
+      author = Author.create(),
+      secondAuthor = Author.create();
+
+  Ember.run(function() {
+    author.load(100, {id: 100, name: 'bob'});
+    secondAuthor.load(101, {id: 101, name: 'ray'});
+    post.load(1, {id: 1, author_id: 100});
+  });
+
+  Ember.run(function() {
+    post.set('author', null);
+  });
+
+  ok(post.get('isDirty'));
+});
+
 test("relationships should be seralized when specified with string", function() {
   expect(1);
 


### PR DESCRIPTION
The `if (value)` was to greedy and not setting the dirtyAttributes if the value was falsy (null or undefined).

The only thing that might suck about this fix is you could now set a relationship to `false` and you won't get an assert. 
