### PR TITLE
Opt out of cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .DS_Store
 tests/index.html
 dist/
+.idea/

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -598,16 +598,21 @@ Ember.Model.reopenClass({
   },
 
   cachedRecordForId: function(id) {
-    var record = this.getCachedReferenceRecord(id);
+    var record;
+    if (!this.transient) {
+      record = this.getCachedReferenceRecord(id);
+    }
 
     if (!record) {
       var primaryKey = get(this, 'primaryKey'),
         attrs = {isLoaded: false};
       attrs[primaryKey] = id;
       record = this.create(attrs);
-      var sideloadedData = this.sideloadedData && this.sideloadedData[id];
-      if (sideloadedData) {
-        record.load(id, sideloadedData);
+      if (!this.transient) {
+        var sideloadedData = this.sideloadedData && this.sideloadedData[id];
+        if (sideloadedData) {
+          record.load(id, sideloadedData);
+        }
       }
     }
 

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -111,6 +111,23 @@ test(".find([]) called with a single record returns cache before delgating to ad
   ok(record, "Record was returned by find");
 });
 
+test(".find([]) called when Model.transient true always delegates to adapter's find", function() {
+  expect(3);
+
+  Model.transient = true;
+  Model.load([{ token: 'a', name: 'Yehuda' }]);
+  Model.adapter = Ember.FixtureAdapter.extend({
+    find: function() {
+      ok(true, "record should not get loaded from cache");
+      return this._super.apply(this, arguments);
+    }
+  }).create();
+
+  var record = Ember.run(Model, Model.find, ['a']);
+  Ember.run(Model, Model.find, 'a');
+  ok(record, "Record was returned by find");
+});
+
 test(".reload() loads the record via the adapter after it was loaded", function() {
   expect(1);
 


### PR DESCRIPTION
Probably a naive approach ...

Developers can define "transient: false" on their classes that extend Ember.Model, this will skip the cache check.
