### PR TITLE
Added clearing of _findAllRecordArray to clearCache call

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -640,6 +640,7 @@ Ember.Model.reopenClass({
   clearCache: function () {
     this.sideloadedData = undefined;
     this._referenceCache = undefined;
+    this._findAllRecordArray = undefined;
   },
 
   removeFromCache: function (key) {

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -787,6 +787,19 @@ test("fetchMany resolves with error object", function() {
   stop();
 });
 
+test(".clearCache destroys _findAllRecordArray reference", function() {
+  expect(1);
+
+  var records = Model.find();
+  records.on('didLoad', function() {
+    start();
+
+    Model.clearCache();
+    var newRecords = Model.find();
+    equal( newRecords.get( 'isLoaded' ), false, "clearCache should clear _findAllRecordArray" );
+  });
+  stop();
+});
 // TODO: test that creating a record calls load
 
 // test('Model#registerRecordArray', function(){


### PR DESCRIPTION
This fixes a problem I ran into where I was attempting to use clearCache to force a reload of an entire data set, only to find that clearCache doesn't actually clear the _findAllRecordArray.  That seemed to be the place that made the most sense, so I added that to the list of items cleared by clearCache.
