### PR TITLE
Fix re-dirtying embedded hasMany after save

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -291,15 +291,15 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   _resetDirtyStateInNestedObjects: function(object) {
-    var i;
+    var i, obj;
     if (object._hasManyArrays) {
       for (i = 0; i < object._hasManyArrays.length; i++) {
         var array = object._hasManyArrays[i];
         if (array.embedded) {
           array.revert();
           for (var j = 0; j < array.get('length'); j++) {
-            set(array.objectAt(j),'_dirtyAttributes', []);
-            this._resetDirtyStateInNestedObjects(array.objectAt(j));
+            obj = array.objectAt(j);
+            obj._copyDirtyAttributesToData();
           }
         }
       }
@@ -309,7 +309,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
       for (i = 0; i < object._belongsTo.length; i++) {
         var belongsTo = object._belongsTo[i];
         if (belongsTo.options.embedded) {
-          var obj = this.get(belongsTo.relationshipKey);
+          obj = this.get(belongsTo.relationshipKey);
           obj._copyDirtyAttributesToData();
         }
       }

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -412,7 +412,7 @@ test("_modifiedRecords property should be clean after clearing hasMany array", f
 });
 
 test("isDirty on embedded hasMany records should be false after parent is saved", function() {
-  expect(7);
+  expect(9);
 
   var Comment = Ember.Model.extend({
     body: attr()
@@ -453,6 +453,10 @@ test("isDirty on embedded hasMany records should be false after parent is saved"
     equal(post.get('isDirty'), false, "parent should not be dirty");
     equal(post.get('comments.firstObject.isDirty'), false, 'child should not be dirty');
     equal(post.get('comments.firstObject.body'), 'New body', 'updated child property is saved');
+
+    post.set('comments.firstObject.body', 'The body');
+    equal(post.get('isDirty'), true, 'parent should be dirty again');
+    equal(post.get('comments.firstObject.isDirty'), true, 'child should be dirty again');
   });
 });
 


### PR DESCRIPTION
After saving an embedded has-many array, changing an item back to its original value will set isDirty = false. This happens because `_data` reflects the old state before the save.

I'll fix this when I have a chance
