### PR TITLE
rootKeys and collectionKeys should be able to access nested json payload...

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -15,7 +15,7 @@ Ember.RESTAdapter = Ember.Adapter.extend({
 
   didFind: function(record, id, data) {
     var rootKey = get(record.constructor, 'rootKey'),
-        dataToLoad = rootKey ? data[rootKey] : data;
+        dataToLoad = rootKey ? get(data, rootKey) : data;
 
     record.load(id, dataToLoad);
   },
@@ -32,7 +32,7 @@ Ember.RESTAdapter = Ember.Adapter.extend({
 
   didFindAll: function(klass, records, data) {
     var collectionKey = get(klass, 'collectionKey'),
-        dataToLoad = collectionKey ? data[collectionKey] : data;
+        dataToLoad = collectionKey ? get(data, collectionKey) : data;
 
     records.load(klass, dataToLoad);
   },
@@ -49,7 +49,7 @@ Ember.RESTAdapter = Ember.Adapter.extend({
 
   didFindQuery: function(klass, records, params, data) {
       var collectionKey = get(klass, 'collectionKey'),
-          dataToLoad = collectionKey ? data[collectionKey] : data;
+          dataToLoad = collectionKey ? get(data, collectionKey) : data;
 
       records.load(klass, dataToLoad);
   },
@@ -67,7 +67,8 @@ Ember.RESTAdapter = Ember.Adapter.extend({
   didCreateRecord: function(record, data) {
     var rootKey = get(record.constructor, 'rootKey'),
         primaryKey = get(record.constructor, 'primaryKey'),
-        dataToLoad = rootKey ? data[rootKey] : data;
+        dataToLoad = rootKey ? get(data, rootKey) : data;
+        
     record.load(dataToLoad[primaryKey], dataToLoad);
     record.didCreateRecord();
   },


### PR DESCRIPTION
``` javascript
App.Person.collectionKey = 'ResponseObject.people';
App.Person.rootKey = 'ResponseObject.person';
```

I think you should be able to traverse a json object by passing chained collectionKey/rootKey. I've run into a couple APIs where the object is actually nested 1 or 2 levels deep. Since the perceived performance difference is undetectable  I think it's worth having this be the default behavior.
