### PR TITLE
Removed duplicate test

### DIFF
--- a/packages/ember-model/tests/store_test.js
+++ b/packages/ember-model/tests/store_test.js
@@ -57,11 +57,6 @@ test("store.createRecord(type) returns a record with a container", function() {
   equal(record.container, container);
 });
 
-test("store.createRecord(type) returns a record with a container", function() {
-  var record = Ember.run(store, store.createRecord, 'test');
-  equal(record.container, container);
-});
-
 test("store.find(type) returns a record with hasMany and belongsTo that should all have a container", function() {
   expect(3);
   var promise = Ember.run(store, store.find, 'test', 'a');


### PR DESCRIPTION
While checking out #328, I noticed a test may have been inadvertently copy/pasted:

"store.createRecord(type) returns a record with a container"

https://github.com/ebryn/ember-model/blob/master/packages/ember-model/tests/store_test.js#L55
https://github.com/ebryn/ember-model/blob/master/packages/ember-model/tests/store_test.js#L60
