### PR TITLE
Fix undefined container on hasMany relationship records. Part Fix #328

### DIFF
--- a/packages/ember-model/lib/has_many.js
+++ b/packages/ember-model/lib/has_many.js
@@ -15,13 +15,13 @@ Ember.hasMany = function(type, options) {
     if (arguments.length > 1) {
       return existingArray.setObjects(newContentArray);
     } else {
-      return this.getHasMany(key, type, meta);
+      return this.getHasMany(key, type, meta, this.container);
     }
   }).property().meta(meta);
 };
 
 Ember.Model.reopen({
-  getHasMany: function(key, type, meta) {
+  getHasMany: function(key, type, meta, container) {
     var embedded = meta.options.embedded,
         collectionClass = embedded ? Ember.EmbeddedHasManyArray : Ember.HasManyArray;
 
@@ -31,7 +31,8 @@ Ember.Model.reopen({
       content: this._getHasManyContent(key, type, embedded),
       embedded: embedded,
       key: key,
-      relationshipKey: meta.relationshipKey
+      relationshipKey: meta.relationshipKey,
+      container: container
     });
 
     this._registerHasManyArray(collection);

--- a/packages/ember-model/lib/has_many_array.js
+++ b/packages/ember-model/lib/has_many_array.js
@@ -35,7 +35,7 @@ Ember.ManyArray = Ember.RecordArray.extend({
     // need to add observer if it wasn't materialized before
     var observerNeeded = (content[idx].record) ? false : true;
 
-    var record = this.materializeRecord(idx);
+    var record = this.materializeRecord(idx, this.container);
     
     if (observerNeeded) {
       var isDirtyRecord = record.get('isDirty'), isNewRecord = record.get('isNew');
@@ -153,7 +153,7 @@ Ember.ManyArray = Ember.RecordArray.extend({
 });
 
 Ember.HasManyArray = Ember.ManyArray.extend({
-  materializeRecord: function(idx) {
+  materializeRecord: function(idx, container) {
     var klass = get(this, 'modelClass'),
         content = get(this, 'content'),
         reference = content.objectAt(idx),
@@ -165,6 +165,7 @@ Ember.HasManyArray = Ember.ManyArray.extend({
       record = klass.find(reference.id);
     }
 
+    record.container = container;
     return record;
   },
 
@@ -191,23 +192,26 @@ Ember.EmbeddedHasManyArray = Ember.ManyArray.extend({
     return record; // FIXME: inject parent's id
   },
 
-  materializeRecord: function(idx) {
+  materializeRecord: function(idx, container) {
     var klass = get(this, 'modelClass'),
         primaryKey = get(klass, 'primaryKey'),
         content = get(this, 'content'),
         reference = content.objectAt(idx),
         attrs = reference.data;
 
+    var record;
     if (reference.record) {
-      return reference.record;
+      record = reference.record;
     } else {
-      var record = klass.create({ _reference: reference });
+      record = klass.create({ _reference: reference });
       reference.record = record;
       if (attrs) {
         record.load(attrs[primaryKey], attrs);
       }
-      return record;
     }
+
+    record.container = container;
+    return record;
   },
 
   toJSON: function() {

--- a/packages/ember-model/tests/store_test.js
+++ b/packages/ember-model/tests/store_test.js
@@ -58,13 +58,16 @@ test("store.createRecord(type) returns a record with a container", function() {
 });
 
 test("store.find(type) returns a record with hasMany and belongsTo that should all have a container", function() {
-  expect(3);
+  expect(4);
   var promise = Ember.run(store, store.find, 'test', 'a');
   promise.then(function(record) {
     start();
     ok(record.get('container'));
     ok(record.get('embeddedBelongsTo').get('container'));
-    ok(record.get('embeddedHasmany.firstObject').get('container'));
+
+    record.get('embeddedHasmany').forEach(function(embeddedBelongsToRecord) {
+      ok(embeddedBelongsToRecord.get('container'));
+    });
   });
   stop();
 });


### PR DESCRIPTION
@josbeir Addressing failing test in https://github.com/ebryn/ember-model/pull/330 Thanks for catching!

Looks like none of the records returned in hasMany had container explicitly set. Container was only set if it was cached previously. Ideally I'd like to have a PR after this one in an attempt at consolidating record creation.
