### PR TITLE
Register application store if exists. Fix tests to use App.destroy.

### DIFF
--- a/packages/ember-model/lib/store.js
+++ b/packages/ember-model/lib/store.js
@@ -46,7 +46,7 @@ Ember.onLoad('Ember.Application', function(Application) {
     name: "store",
 
     initialize: function(container, application) {
-      application.register('store:main', Ember.Model.Store);
+      application.register('store:main', container.lookupFactory('store:application') || Ember.Model.Store);
 
       application.inject('route', 'store', 'store:main');
       application.inject('controller', 'store', 'store:main');

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -53,7 +53,10 @@ test("model can be specified with a string instead of a class", function() {
 });
 
 test("model can be specified with a string to a resolved path", function() {
-  var App = Ember.Application.create({rootElement: "#qunit-fixture"});
+  var App;
+  Ember.run(function() {
+    App = Ember.Application.create({});
+  });
   App.Article  = Ember.Model.extend({
       id: Ember.attr(String)
     });
@@ -67,7 +70,7 @@ test("model can be specified with a string to a resolved path", function() {
 
   equal(article.get('id'), 'a');
   ok(article instanceof App.Article);
-  App.reset();
+  Ember.run(App, 'destroy');
 });
 
 test("non embedded belongsTo should get a record by its id", function() {

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -85,8 +85,11 @@ test("model can be specified with a string instead of a class", function() {
 });
 
 test("model can be specified with a string to a resolved path", function() {
+  var App;
+  Ember.run(function() {
+    App = Ember.Application.create({});
+  });
 
-  var App = Ember.Application.create({rootElement:"#qunit"});
   App.Comment = Ember.Model.extend({
     id: Ember.attr(String)
   });
@@ -99,7 +102,8 @@ test("model can be specified with a string to a resolved path", function() {
 
   equal(article.get('comments.length'), 2);
   equal(Ember.run(article, article.get, 'comments.firstObject.id'), 'a');
-  App.reset();
+
+  Ember.run(App, 'destroy');
 });
 
 test("when fetching an association getHasMany is called", function() {

--- a/packages/ember-model/tests/store_test.js
+++ b/packages/ember-model/tests/store_test.js
@@ -1,4 +1,4 @@
-var TestModel, EmbeddedModel, store, container;
+var TestModel, EmbeddedModel, store, container, App;
 
 module("Ember.Model.Store", {
   setup: function() {
@@ -163,4 +163,22 @@ test("store.find(type) records use application adapter if no klass.adapter or ty
   });
 
   stop();
+});
+
+test("Registering a custom store on application works", function() {
+  Ember.run(function() {
+    App = Ember.Application.create({
+      TestRoute: Ember.Route.extend()
+    });
+    App.ApplicationStore = Ember.Model.Store.extend({ custom: true });
+  });
+
+  container = App.__container__;
+  ok(container.lookup('store:application'));
+  ok(container.lookup('store:main').get('custom'));
+
+  var testRoute = container.lookup('route:test');
+  ok(testRoute.get('store.custom'));
+
+  Ember.run(App, 'destroy');
 });


### PR DESCRIPTION
Instead of a rename of store to applicationStore, I am allowing the developer to extend store with their own implementation of application store. If we'd rather straight up override store for them, I can do the rename. Thoughts!
