### PR TITLE
Rename dataAdapter to data-adapter

### DIFF
--- a/packages/ember-model/lib/debug_adapter.js
+++ b/packages/ember-model/lib/debug_adapter.js
@@ -105,10 +105,10 @@ var DebugAdapter = Ember.DataAdapter.extend({
 
 Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
-    name: "dataAdapter",
+    name: "data-adapter",
 
     initialize: function(container, application) {
-      application.register('dataAdapter:main', DebugAdapter);
+      application.register('data-adapter:main', DebugAdapter);
     }
   });
 });


### PR DESCRIPTION
Latest Ember requires a dasherized name in the container.
