### PR TITLE
Default relationship key to the property key

### DIFF
--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -20,12 +20,13 @@ function getType(record) {
 Ember.belongsTo = function(type, options) {
   options = options || {};
 
-  var meta = { type: type, isRelationship: true, options: options, kind: 'belongsTo', getType: getType },
-      relationshipKey = options.key;
+  var meta = { type: type, isRelationship: true, options: options, kind: 'belongsTo', getType: getType};
 
-  return Ember.computed(function(key, value, oldValue) {
+  return Ember.computed(function(propertyKey, value, oldValue) {
     type = meta.getType(this);
     Ember.assert("Type cannot be empty.", !Ember.isEmpty(type));
+
+    var key = options.key || propertyKey;
 
     var dirtyAttributes = get(this, '_dirtyAttributes'),
         createdDirtyAttributes = false,
@@ -33,9 +34,9 @@ Ember.belongsTo = function(type, options) {
 
     var dirtyChanged = function(sender) {
       if (sender.get('isDirty')) {
-        self._relationshipBecameDirty(relationshipKey);
+        self._relationshipBecameDirty(key);
       } else {
-        self._relationshipBecameClean(relationshipKey);
+        self._relationshipBecameClean(key);
       }
     };
 
@@ -53,9 +54,9 @@ Ember.belongsTo = function(type, options) {
       }
 
       if (oldValue !== value) {
-        dirtyAttributes.pushObject(key);
+        dirtyAttributes.pushObject(propertyKey);
       } else {
-        dirtyAttributes.removeObject(key);
+        dirtyAttributes.removeObject(propertyKey);
       }
 
       if (createdDirtyAttributes) {
@@ -73,7 +74,7 @@ Ember.belongsTo = function(type, options) {
 
       return value === undefined ? null : value;  
     } else {
-      value = this.getBelongsTo(relationshipKey, type, meta);
+      value = this.getBelongsTo(key, type, meta);
       this._registerBelongsTo(meta);
       if (value !== null && meta.options.embedded) {
         value.get('isDirty'); // getter must be called before adding observer

--- a/packages/ember-model/lib/has_many.js
+++ b/packages/ember-model/lib/has_many.js
@@ -1,24 +1,31 @@
 var get = Ember.get;
 
+function getType(record) {
+  var type = this.type;
+
+  if (typeof this.type === "string" && this.type) {
+    this.type = Ember.get(Ember.lookup, this.type);
+
+    if (!this.type) {
+      var store = Ember.Model.Store.create({ container: record.container });
+      this.type = store.modelFor(type);
+      this.type.reopenClass({ adapter: store.adapterFor(type) });
+    }
+  }
+
+  return this.type;
+}
+
 Ember.hasMany = function(type, options) {
   options = options || {};
 
-  var meta = { type: type, isRelationship: true, options: options, kind: 'hasMany' },
-      key = options.key;
+  var meta = { type: type, isRelationship: true, options: options, kind: 'hasMany', getType: getType};
 
   return Ember.computed(function(propertyKey, newContentArray, existingArray) {
+    type = meta.getType(this);
     Ember.assert("Type cannot be empty", !Ember.isEmpty(type));
-    if (typeof type === "string") {
-      
-      var typeName = type;
-      type = Ember.get(Ember.lookup, typeName);
 
-      if (!type) {
-        var store = Ember.Model.Store.create({ container: this.container });
-        type = store.modelFor(typeName);
-        type.reopenClass({ adapter: store.adapterFor(typeName) });
-      }
-    }
+    var key = options.key || propertyKey;
 
     if (arguments.length > 1) {
       return existingArray.setObjects(newContentArray);

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -615,3 +615,24 @@ test("embedded belongsTo with undefined value", function() {
   Ember.run(post, post.load, json.id, json);
   equal(post.get('author'), null);
 });
+
+test("key defaults to model's property key", function() {
+  expect(1);
+
+  var Article = Ember.Model.extend({
+    id: Ember.attr()
+  });
+
+  Article.adapter = Ember.FixtureAdapter.create();
+  Article.FIXTURES = [{ id: 2 }];
+
+  var Comment = Ember.Model.extend({
+    article: Ember.belongsTo(Article)
+  });
+
+  var comment = Comment.create();
+
+  Ember.run(comment, comment.load, 1, { article: 2 });
+
+  deepEqual(comment.toJSON(), { article: 2 });
+});

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -259,3 +259,20 @@ test("relationship type cannot be empty", function() {
   /Type cannot be empty/);
 
 });
+
+test("key defaults to model's property key", function() {
+  expect(1);
+
+  var Comment = Ember.Model.extend({
+      id: Ember.attr()
+    }),
+    Article = Ember.Model.extend({
+      comments: Ember.hasMany(Comment)
+    });
+
+  var article = Article.create();
+
+  Ember.run(article, article.load, 1, { comments: Ember.A(['a'] )});
+
+  deepEqual(article.toJSON(), { comments: ['a'] });
+});


### PR DESCRIPTION
Make it so relationships don't need to specify a key if it's the same as the property value. 
Instead of `comments: Ember.hasMany(Comment, {key: 'comments'})`
It can be `comments: Ember.hasMany(Comment)`

Also some refactoring of has_many so it looks similar to belong_to.
