### PR TITLE
Fix re-dirtying non-embedded hasMany after save

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -295,8 +295,8 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
     if (object._hasManyArrays) {
       for (i = 0; i < object._hasManyArrays.length; i++) {
         var array = object._hasManyArrays[i];
+        array.revert();
         if (array.embedded) {
-          array.revert();
           for (var j = 0; j < array.get('length'); j++) {
             obj = array.objectAt(j);
             obj._copyDirtyAttributesToData();

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -256,11 +256,13 @@ test("isDirty is observable", function() {
 });
 
 test("manipulating object presence in a hasMany should dirty the parent", function() {
+  expect(7);
   var Comment = Ember.Model.extend();
 
   var Post = Ember.Model.extend({
     comments: Ember.hasMany(Comment, {key: 'comments'})
   });
+  Post.adapter = Ember.FixtureAdapter.create();
 
   var post = Post.create({isNew: false, _data: {comments: []}});
 
@@ -276,6 +278,21 @@ test("manipulating object presence in a hasMany should dirty the parent", functi
   comments.removeObject(newComment);
 
   ok(!post.get('isDirty'), "After reversing the change, the post should be clean again");
+
+  comments.pushObject(newComment);
+  stop();
+  Ember.run(function() {
+    post.save().then(function() {
+      start();
+      ok(!post.get('isDirty'), "The post is clean after being saved");
+
+      comments.removeObject(newComment);
+      ok(post.get('isDirty'), "After being modified, the post should be dirty");
+
+      comments.pushObject(newComment);
+      ok(!post.get('isDirty'), "After reverting to the saved state, the post should be clean again");
+    });
+  });
 });
 
 test("manipulating the order of objects in a hasMany shouldn't dirty the parent", function() {


### PR DESCRIPTION
The same problem as #322 but with non-embedded hasMany arrays. We still need to update the original state after save in the non-embedded case.
