### PR TITLE
FixtureAdapter.createRecord - handle the `rootKey` property

### DIFF
--- a/packages/ember-model/lib/fixture_adapter.js
+++ b/packages/ember-model/lib/fixture_adapter.js
@@ -80,8 +80,12 @@ Ember.FixtureAdapter = Ember.Adapter.extend({
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
       Ember.run.later(this, function() {
+        var rootKey = record.constructor.rootKey,
+            json;
+
         self._setPrimaryKey(record);
-        fixtures.push(klass.findFromCacheOrLoad(record.toJSON()));
+        json = rootKey ? record.toJSON()[rootKey] : record.toJSON();
+        fixtures.push(klass.findFromCacheOrLoad(json));
         record.didCreateRecord();
         resolve(record);
       }, 0);

--- a/packages/ember-model/tests/adapter/fixture_adapter_test.js
+++ b/packages/ember-model/tests/adapter/fixture_adapter_test.js
@@ -82,6 +82,22 @@ test("createRecord", function() {
   stop();
 });
 
+test("createRecord - handle the case when the `rootKey` property is set", function () {
+  expect(1);
+
+  FixtureModel.rootKey = "fixture";
+  FixtureModel.FIXTURES = [];
+
+  var record = FixtureModel.create({name: "Erik"});
+
+  Ember.run(record, record.save).then(function () {
+    start();
+    var record = FixtureModel.find("fixture-0");
+    deepEqual(record.get("_data"), {id: "fixture-0", name: "Erik"}, "Data is set correctly");
+  });
+  stop();
+});
+
 test("_generatePrimaryKey", function() {
   expect(3);
 


### PR DESCRIPTION
When the `rootKey` property is set, the output of the `toJSON` method looks the following way: `{rootKey: <data>}`. FixtureAdapter.createRecord does not take this into account.
