### PR TITLE
Use shortcut for ember get

### DIFF
--- a/packages/ember-model/lib/has_many.js
+++ b/packages/ember-model/lib/has_many.js
@@ -4,7 +4,7 @@ function getType(record) {
   var type = this.type;
 
   if (typeof this.type === "string" && this.type) {
-    this.type = Ember.get(Ember.lookup, this.type);
+    this.type = get(Ember.lookup, this.type);
 
     if (!this.type) {
       var store = record.container.lookup('store:main');


### PR DESCRIPTION
I simply updated the code where it was doing an Ember.get to use the already defined shortcut of get.
