### PR TITLE
Add attribute level save/update control

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -176,10 +176,16 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
         attributes = this.constructor.getAttributes(),
         relationships = this.constructor.getRelationships(),
         properties = attributes ? this.getProperties(attributes) : {},
-        rootKey = get(this.constructor, 'rootKey');
+        rootKey = get(this.constructor, 'rootKey'),
+        isNew = get(this, 'isNew');
 
     for (key in properties) {
       meta = this.constructor.metaForProperty(key);
+      if (meta.options) {
+        if (meta.options.save === false || (meta.options.update === false && ! isNew)) {
+          continue;
+        }
+      }
       if (meta.type && meta.type.serialize) {
         json[this.dataKey(key)] = meta.type.serialize(properties[key]);
       } else if (meta.type && Ember.Model.dataTypes[meta.type]) {
@@ -195,6 +201,11 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
       for(var i = 0; i < relationships.length; i++) {
         key = relationships[i];
         meta = this.constructor.metaForProperty(key);
+        if (meta.options) {
+          if (meta.options.save === false || (meta.options.update === false && ! isNew)) {
+            continue;
+          }
+        }
         relationshipKey = meta.options.key || key;
 
         if (meta.kind === 'belongsTo') {


### PR DESCRIPTION
This PR add the ability to control what attributes or relationships are sent back to the server as sometimes is it is undesirable to send everything back, e.g. read-only attributes or other meta data managed by the server or relationships which should not be managed through the model.

On your model you can now do:

```
var Person = Model.extend({
   createdAt: Ember.attr(Date, {update: false}),
   searchHits: Ember.attr(Number, {save: false}),
   friendships: Ember.hasMany('App.Friendship', {save: false})
});
```

The `save: false` option prevents the attribute ever being sent on a create or update, whilst the `update: false` option will never update the attribute, but does allow the value to be sent on a create.  This control is intended to be independent/orthogonal of any adapter implementation since it controls the `toJSON()` serialisation of the model which occurs prior to the data being given to the adapter for persistence.
