### PR TITLE
Support HEAD response (undefined response body) on RESTAdapter

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -158,10 +158,13 @@ Ember.RESTAdapter = Ember.Adapter.extend({
 
   _loadRecordFromData: function(record, data) {
     var rootKey = get(record.constructor, 'rootKey'),
-        primaryKey = get(record.constructor, 'primaryKey'),
-        dataToLoad = rootKey ? get(data, rootKey) : data;
-    if (!Ember.isEmpty(dataToLoad)) {
-      record.load(dataToLoad[primaryKey], dataToLoad);
+        primaryKey = get(record.constructor, 'primaryKey');
+    // handle HEAD response where no data is provided by server
+    if (data) {
+      data = rootKey ? get(data, rootKey) : data;
+      if (!Ember.isEmpty(data)) {
+        record.load(data[primaryKey], data);
+      }
     }
   }
 });

--- a/packages/ember-model/tests/adapter/rest_adapter_test.js
+++ b/packages/ember-model/tests/adapter/rest_adapter_test.js
@@ -569,6 +569,25 @@ test("saveRecord does not load empty response", function() {
   equal(record.get('name'), 'John', 'Record should not have been reloaded.');
 });
 
+test("saveRecord does not load HEAD response (undefined response body)", function() {
+  expect(4);
+  var record = Ember.run(RESTModel, RESTModel.create, {id: 1, name: "Erik", isNew: false}),
+      responseData = '';
+
+  record.set('name', 'John');
+  ok(record.get('isDirty'), 'Record should be dirty');
+
+  adapter._ajax = function(url, params, method) {
+    return ajaxSuccess(undefined);
+  };
+
+  Ember.run(record, record.save);
+
+  ok(!record.get('isDirty'), 'Record should not be dirty');
+  ok(!record.get('isSaving'), 'Record should not be saving');
+  equal(record.get('name'), 'John', 'Record should not have been reloaded.');
+});
+
 test("saveRecord does not load response if root key is missing", function() {
   expect(4);
   var record = Ember.run(RESTModel, RESTModel.create, {id: 1, name: "Erik", isNew: false}),


### PR DESCRIPTION
This PR allows the `RESTAdapter` to handle HEAD responses which have an undefined response body, as distinct from an empty response body.

Test included.
