### PR TITLE
Add assertion error for incorrect relationship type

### DIFF
--- a/packages/ember-model/lib/store.js
+++ b/packages/ember-model/lib/store.js
@@ -2,7 +2,11 @@ Ember.Model.Store = Ember.Object.extend({
   container: null,
 
   modelFor: function(type) {
-    return this.container.lookupFactory('model:'+type);
+    if (typeof type === 'string') {
+      return this.container.lookupFactory('model:'+type);
+    } else {
+      return type;
+    }
   },
 
   adapterFor: function(type) {

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -726,3 +726,26 @@ test("non embedded belongsTo should return a record with a container", function(
     ok(article.get('container'));
   });
 });
+
+test("model cannot be specified as an object if container exists", function() {
+  var App;
+  Ember.run(function() {
+    App = Ember.Application.create({});
+  });
+  App.Article  = Ember.Model.extend({
+    id: Ember.attr(String)
+  });
+  App.Comment = Ember.Model.extend({
+    article: Ember.belongsTo(App.Article, { key: 'article', embedded: true })
+  });
+
+  var comment = App.Comment.create({container: App.__container__});
+  Ember.run(comment, comment.load, 1, { article: { id: 'a' } });
+
+  expectAssertion(function() {
+      comment.get('article');
+    },
+    /Models created from store must define relationships with strings not objects. Using convention 'post' not 'App.Post'/);
+
+  Ember.run(App, 'destroy');
+});

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -95,10 +95,10 @@ test("model can be specified with a string to a resolved path", function() {
   });
   App.Comment = Ember.Model.extend({
     id: Ember.attr(String),
-    subComments: Ember.hasMany('subcomment', { key: 'subcomments', embedded: true })
+    subComments: Ember.hasMany('subcomment', {embedded: true })
   });
   App.Article = Ember.Model.extend({
-    comments: Ember.hasMany('comment', { key: 'comments', embedded: true })
+    comments: Ember.hasMany('comment', {embedded: true })
   });
 
   var article = App.Article.create({container: App.__container__});
@@ -275,4 +275,29 @@ test("key defaults to model's property key", function() {
   Ember.run(article, article.load, 1, { comments: Ember.A(['a'] )});
 
   deepEqual(article.toJSON(), { comments: ['a'] });
+});
+
+test("model cannot be specified as an object if container exists", function() {
+  var App;
+  Ember.run(function() {
+    App = Ember.Application.create({});
+  });
+
+  App.Comment = Ember.Model.extend({
+    id: Ember.attr()
+  });
+  App.Article = Ember.Model.extend({
+    comments: Ember.hasMany(App.Comment, {embedded: true })
+  });
+
+  var article = App.Article.create({container: App.__container__});
+
+  Ember.run(article, article.load, 1, {comments: Ember.A([{id: 'a'}, {id: 'b'}])});
+
+  expectAssertion(function() {
+      article.get('comments');
+    },
+    /Models created from store must define relationships with strings not objects. Using convention 'post' not 'App.Post'/);
+
+  Ember.run(App, 'destroy');
 });


### PR DESCRIPTION
Throw an assertion error if the user is creating records via store, but does not define their relationships in such a way that will continue using the store.  Relationships must be defined as a string, `post` and not `App.Post` if the record has a container. This is to ensure the application is creating records with a container - all or nothing.
