### PR TITLE
Embedded associations remain dirty after saving new record

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -251,7 +251,6 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
 
     set(this, 'isNew', false);
 
-    set(this, '_dirtyAttributes', []);
     this.constructor.addToRecordArrays(this);
     this.trigger('didCreateRecord');
     this.didSaveRecord();


### PR DESCRIPTION
Setting _dirtyAttributes in didCreateRecord blocks execution of _copyDirtyAttributesToData in didSaveRecord which resets _dirtyAttributes also in hasMany/belongsTo associations. This leads to bugs: after saving newly created record, associations remain dirty while parent object is clean. Fix is simple, just rely on didSaveRecord to do all cleanup.
