### PR TITLE
Fix #364. ensure a record is always passed to getType()

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -165,7 +165,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
       var record = this.get(key);
       return record ? record.toJSON() : null;
     } else {
-      var primaryKey = get(meta.getType(), 'primaryKey');
+      var primaryKey = get(meta.getType(this), 'primaryKey');
       return this.get(key + '.' + primaryKey);
     }
   },


### PR DESCRIPTION
@ckung I'm still getting this error after your previous changes:

```
Uncaught TypeError: Cannot read property 'container' of undefined 
```

Ensuring the record always gets passed to getType fixes the issue and all tests still pass.
