### PR TITLE
Allow properties to be passed to store createRecord

### DIFF
--- a/packages/ember-model/lib/store.js
+++ b/packages/ember-model/lib/store.js
@@ -22,10 +22,10 @@ Ember.Model.Store = Ember.Object.extend({
     }
   },
 
-  createRecord: function(type) {
+  createRecord: function(type, props) {
     var klass = this.modelFor(type);
     klass.reopenClass({adapter: this.adapterFor(type)});
-    return klass.create({container: this.container});
+    return klass.create(Ember.merge({container: this.container}, props));
   },
 
   find: function(type, id) {

--- a/packages/ember-model/tests/store_test.js
+++ b/packages/ember-model/tests/store_test.js
@@ -57,6 +57,14 @@ module("Ember.Model.Store", {
 test("store.createRecord(type) returns a record with a container", function() {
   var record = Ember.run(store, store.createRecord, 'test');
   equal(record.container, container);
+  equal(record.container, container);
+});
+
+test("store.createRecord(type) with properties", function() {
+  expect(2);
+  var record = Ember.run(store, store.createRecord, 'test', {token: 'c', name: 'Andrew'});
+  equal(record.get('token'), 'c');
+  equal(record.get('name'), 'Andrew');
 });
 
 test("store.find(type) returns a record with hasMany and belongsTo that should all have a container", function() {


### PR DESCRIPTION
This allows properties to be passed to the store`createRecord()` function and brings Ember Model's `createRecord()` function into alignment with `DS createRecord()`.

Test included.
