### PR TITLE
Fix belongs_to dirty change to use correct key

### DIFF
--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -42,9 +42,9 @@ Ember.belongsTo = function(type, options) {
 
     var dirtyChanged = function(sender) {
       if (sender.get('isDirty')) {
-        self._relationshipBecameDirty(key);
+        self._relationshipBecameDirty(propertyKey);
       } else {
-        self._relationshipBecameClean(key);
+        self._relationshipBecameClean(propertyKey);
       }
     };
 

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -581,6 +581,51 @@ test("save parent of embedded belongsTo", function() {
   });
 });
 
+test("save parent of embedded belongsTo with different named key", function() {
+  expect(9);
+  var json = {
+    id: 1,
+    name: 'foo',
+    the_author: { id: 1, name: 'Cory Loken' }
+  };
+
+  var Author = Ember.Model.extend({
+        id: Ember.attr(),
+        name: Ember.attr()
+      }),
+      Post = Ember.Model.extend({
+        id: Ember.attr(),
+        author: Ember.belongsTo(Author, {key: 'the_author', embedded: true})
+      });
+
+  Post.adapter = Ember.FixtureAdapter.create();
+
+  var post = Post.create();
+  Ember.run(post, post.load, json.id, json);
+  equal(post.get('isDirty'), false, 'post should be clean initially');
+
+  post.set('author.name', 'Billy Bob');
+  equal(post.get('author.isDirty'), true, 'author should be dirty after being modified');
+  equal(post.get('isDirty'), true, 'changes to embedded belongsTo should dirty the parent');
+
+  stop();
+  Ember.run(function() {
+    post.save().then(function() {
+      start();
+      equal(post.get('author.isDirty'), false, 'the author should be clean after being saved');
+      equal(post.get('isDirty'), false, 'the post should be clean after being saved');
+
+      post.set('author.name', 'John Doe');
+      equal(post.get('author.isDirty'), true, 'the author should be dirty again');
+      equal(post.get('isDirty'), true, 'the post should be dirty because the author is dirty');
+
+      post.set('author.name', 'Cory Loken'); // special case: setting back to its original value
+      equal(post.get('author.isDirty'), true, 'the author should be dirty because it was saved as "Billy Bob"');
+      equal(post.get('isDirty'), true, 'the post should be dirty because the author is dirty');
+    });
+  });
+});
+
 test("set embedded belongsTo", function() {
   expect(9);
   var json = {


### PR DESCRIPTION
Fixes embedded belongsTo relationship to use the correct key when dirtying the parent.

Without this fix, when using the `key` option on the relationship, the parents dirty attributes will include an incorrect dirty key.  This causes things to blow up in later `didSaveRecord()` .. `_copyDirtyAttributesToData()` .. `dataKey()` .. `this.constructor.metaForProperty(key)` as it tries to use the belongsTo option key, and not the actual property key.

Test included.
