### PR TITLE
Allow model.load to accept container.

### DIFF
--- a/packages/ember-model/lib/has_many_array.js
+++ b/packages/ember-model/lib/has_many_array.js
@@ -168,16 +168,15 @@ Ember.HasManyArray = Ember.ManyArray.extend({
     var klass = get(this, 'modelClass'),
         content = get(this, 'content'),
         reference = content.objectAt(idx),
-        record;
+        record = reference.record;
 
-    if (reference.record) {
-      record = reference.record;
-    } else {
-      record = klass.find(reference.id);
+    if (record) {
+      if (! record.container) {
+        record.container = container;
+      }
+      return record;
     }
-
-    record.container = container;
-    return record;
+    return klass._findFetchById(reference.id, false, container);
   },
 
   toJSON: function() {

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -650,7 +650,9 @@ Ember.Model.reopenClass({
   getCachedReferenceRecord: function(id, container){
     var ref = this._getReferenceById(id);
     if(ref && ref.record) {
-      ref.record.container = container;
+      if (! ref.record.container) {
+        ref.record.container = container;
+      }
       return ref.record;
     }
     return undefined;
@@ -770,7 +772,7 @@ Ember.Model.reopenClass({
     }, this).forEach(callback);
   },
 
-  load: function(hashes) {
+  load: function(hashes, container) {
     if (Ember.typeOf(hashes) !== 'array') { hashes = [hashes]; }
 
     if (!this.sideloadedData) { this.sideloadedData = {}; }
@@ -778,7 +780,7 @@ Ember.Model.reopenClass({
     for (var i = 0, l = hashes.length; i < l; i++) {
       var hash = hashes[i],
           primaryKey = hash[get(this, 'primaryKey')],
-          record = this.getCachedReferenceRecord(primaryKey);
+          record = this.getCachedReferenceRecord(primaryKey, container);
 
       if (record) {
         record.load(primaryKey, hash);

--- a/packages/ember-model/tests/store_test.js
+++ b/packages/ember-model/tests/store_test.js
@@ -1,4 +1,4 @@
-var TestModel, EmbeddedModel, store, container, App;
+var TestModel, EmbeddedModel, UUIDModel, store, container, App;
 
 module("Ember.Model.Store", {
   setup: function() {
@@ -48,8 +48,21 @@ module("Ember.Model.Store", {
     });
     EmbeddedModel.adapter = Ember.FixtureAdapter.create({});
 
+    var uuid = 1234;
+
+    UUIDModel = Ember.Model.extend({
+      init: function() {
+        this.set('id', uuid++);
+        return this._super.apply(this, arguments);
+      },
+      token: Ember.attr(),
+      name: Ember.attr()
+    });
+    EmbeddedModel.adapter = Ember.FixtureAdapter.create({});
+
     container.register('model:test', TestModel);
     container.register('model:embedded', EmbeddedModel);
+    container.register('model:uuid', UUIDModel);
     container.register('store:main', Ember.Model.Store);
   }
 });
@@ -57,6 +70,33 @@ module("Ember.Model.Store", {
 test("store.createRecord(type) returns a record with a container", function() {
   var record = Ember.run(store, store.createRecord, 'test');
   equal(record.container, container);
+});
+
+test("model.load(hashes) returns a existing record with correct container", function() {
+  var model = store.modelFor('uuid'),
+      record = Ember.run(store, store.createRecord, 'uuid');
+
+  equal(model, UUIDModel);
+  equal(record.container, container);
+
+  ok(record.set('token', 'c'));
+
+  equal(record.get('id'), 1234);
+  equal(record.get('token'), 'c');
+
+  model.load({id: 1234, token: 'd', name: 'Andrew'});
+
+  equal(record.get('id'), 1234);
+  equal(record.get('token'), 'd');
+  equal(record.get('name'), 'Andrew');
+  equal(record.get('container'), container);
+
+  model.load({id: 1234, name: 'Peter'}, container);
+
+  equal(record.get('id'), 1234);
+  equal(record.get('token'), undefined);
+  equal(record.get('name'), 'Peter');
+  equal(record.get('container'), container);
 });
 
 test("store.find(type) returns a record with hasMany and belongsTo that should all have a container", function() {


### PR DESCRIPTION
This change adds container support to `Ember.Model.load` so that when loading models from say an adapter those models whether cached or not, will have their container is set correctly.

This PR also ensures that any cached record NEVER has its container modified or set to `undefined` if already set and protects against cases where a container is not passed to a create, find, fetch or load method.

PR includes test.
