### PR TITLE
Replace deprecated Ember.Deferred with Ember.RSVP.defer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.11",
   "main": "ember-model.js",
   "dependencies": {
-    "ember": "~1.5"
+    "ember": "~1.7"
   },
   "devDependencies": {
     "qunit": "~1.11"

--- a/packages/ember-model/lib/load_promise.js
+++ b/packages/ember-model/lib/load_promise.js
@@ -1,27 +1,21 @@
 var get = Ember.get;
 
-Ember.LoadPromise = Ember.Object.extend(Ember.DeferredMixin, {
-  init: function() {
-    this._super.apply(this, arguments);
-
-    var target = get(this, 'target');
-
-    if (get(target, 'isLoaded') && !get(target, 'isNew')) {
-      this.resolve(target);
-    } else {
-      target.one('didLoad', this, function() {
-        this.resolve(target);
-      });
-    }
-  }
-});
-
 Ember.loadPromise = function(target) {
   if (Ember.isNone(target)) {
     return null;
   } else if (target.then) {
     return target;
   } else {
-    return Ember.LoadPromise.create({target: target});
+    var deferred = Ember.RSVP.defer();
+
+    if (get(target, 'isLoaded') && !get(target, 'isNew')) {
+      deferred.resolve(target);
+    } else {
+      target.one('didLoad', this, function() {
+        deferred.resolve(target);
+      });
+    }
+
+    return deferred.promise;
   }
 };

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -474,7 +474,7 @@ Ember.Model.reopenClass({
     }
 
     if (isFetch) {
-      deferred = Ember.Deferred.create();
+      deferred = Ember.RSVP.defer();
       Ember.set(deferred, 'resolveWith', records);
 
       if (!this._currentBatchDeferreds) { this._currentBatchDeferreds = []; }
@@ -483,7 +483,7 @@ Ember.Model.reopenClass({
 
     Ember.run.scheduleOnce('data', this, this._executeBatch, container);
 
-    return isFetch ? deferred : records;
+    return isFetch ? deferred.promise : records;
   },
 
   findAll: function() {
@@ -580,7 +580,7 @@ Ember.Model.reopenClass({
         this._currentBatchRecordArrays = [];
       }
 
-      deferred = Ember.Deferred.create();
+      deferred = Ember.RSVP.defer();
 
       //Attached the record to the deferred so we can resolve it later.
       Ember.set(deferred, 'resolveWith', record);
@@ -590,7 +590,7 @@ Ember.Model.reopenClass({
 
       Ember.run.scheduleOnce('data', this, this._executeBatch, record.container);
 
-      return deferred;
+      return deferred.promise;
     } else {
       return adapter.find(record, id);
     }

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -100,12 +100,12 @@ test("after saving, the model shouldn't be dirty", function() {
   Model.adapter = {
     saveRecord: function(record) {
       ok(true, "saveRecord was called");
-      var deferred = Ember.Deferred.create();
-      deferred.then(function() {
+      var deferred = Ember.RSVP.defer();
+      deferred.promise.then(function() {
         record.didSaveRecord();
       });
       deferred.resolve(record);
-      return deferred;
+      return deferred.promise;
     }
   };
 

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -704,12 +704,12 @@ test("fetchQuery returns a promise", function() {
 test("second promise returned by fetchAll when loading, resolves on load", function() {
   expect(1);
 
-  var deferred = Ember.Deferred.create();
+  var deferred = Ember.RSVP.defer();
 
   var DeferredResolvingAdapter = Ember.FixtureAdapter.extend({
     findAll: function(klass, records, params) {
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        deferred.then(function() {
+        deferred.promise.then(function() {
           records.set('isLoaded', true);
           resolve(records);
         });


### PR DESCRIPTION
`Ember.Deferred` has been deprecated as of Ember 1.7.0-beta.3 (emberjs/ember.js#5215).
