### PR TITLE
parameters for Model#load

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ existingUser.save(); // PUT /users/1
 
 `Model#deleteRecord` - delete a record
 
-`Model#load` - load JSON into the record (typically used inside adapter definition)
+`Model#load(<id>, <object>)` - load JSON into the record (typically used inside adapter definition)
 
 `Model#toJSON` - serialize the record to JSON
 


### PR DESCRIPTION
It is not immediately obvious what the parameters for `Model#load` should be - the default assumption would be `Model#load(<object>)`, but it is actually `Model#load(<id>, <object>)`. Make this explicit in the readme.
