### PR TITLE
Bump Ember version to 1.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.14",
   "main": "ember-model.js",
   "dependencies": {
-    "ember": "~1.7"
+    "ember": "~1.11"
   },
   "devDependencies": {
     "qunit": "~1.11"

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -118,7 +118,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
     var relationships = this.constructor._relationships || [], meta = Ember.meta(this), relationshipKey, relationship, relationshipMeta, relationshipData, relationshipType;
     for (var i = 0, l = relationships.length; i < l; i++) {
       relationshipKey = relationships[i];
-      relationship = meta.descs[relationshipKey];
+      relationship = this[relationshipKey];
       relationshipMeta = relationship.meta();
 
       if (relationshipMeta.options.embedded) {

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -118,7 +118,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
     var relationships = this.constructor._relationships || [], meta = Ember.meta(this), relationshipKey, relationship, relationshipMeta, relationshipData, relationshipType;
     for (var i = 0, l = relationships.length; i < l; i++) {
       relationshipKey = relationships[i];
-      relationship = this[relationshipKey];
+      relationship = (meta.descs || this)[relationshipKey];
       relationshipMeta = relationship.meta();
 
       if (relationshipMeta.options.embedded) {

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -651,9 +651,9 @@ test("toJSON works with string names", function() {
         author: Ember.belongsTo('author', { key: 'author' })
       });
 
-  App.__container__.register('model:comment', Comment);
-  App.__container__.register('model:author', Author);
-  App.__container__.register('model:article', Article);
+  App.registry.register('model:comment', Comment);
+  App.registry.register('model:author', Author);
+  App.registry.register('model:article', Article);
 
   var articleData = {
     id: 1,

--- a/packages/ember-model/tests/record_array_test.js
+++ b/packages/ember-model/tests/record_array_test.js
@@ -18,7 +18,7 @@ module("Ember.RecordArray", {
       {id: 2, name: 'Stefan'},
       {id: 3, name: 'Kris'}
     ];
-    container = new Ember.Container();
+    container = new Ember.Registry().container();
   },
   teardown: function() { }
 });

--- a/packages/ember-model/tests/store_test.js
+++ b/packages/ember-model/tests/store_test.js
@@ -1,8 +1,9 @@
-var TestModel, EmbeddedModel, UUIDModel, store, container, App;
+var TestModel, EmbeddedModel, UUIDModel, store, registry, container, App;
 
 module("Ember.Model.Store", {
   setup: function() {
-    container = new Ember.Container();
+    registry = new Ember.Registry();
+    container = registry.container();
 
     store = Ember.Model.Store.create({container: container});
     TestModel = Ember.Model.extend({
@@ -60,10 +61,10 @@ module("Ember.Model.Store", {
     });
     EmbeddedModel.adapter = Ember.FixtureAdapter.create({});
 
-    container.register('model:test', TestModel);
-    container.register('model:embedded', EmbeddedModel);
-    container.register('model:uuid', UUIDModel);
-    container.register('store:main', Ember.Model.Store);
+    registry.register('model:test', TestModel);
+    registry.register('model:embedded', EmbeddedModel);
+    registry.register('model:uuid', UUIDModel);
+    registry.register('store:main', Ember.Model.Store);
   }
 });
 
@@ -171,16 +172,16 @@ test("store.adapterFor(type) returns klass.adapter first", function() {
 
 test("store.adapterFor(type) returns type adapter if no klass.adapter", function() {
   TestModel.adapter = undefined;
-  container.register('adapter:test', Ember.FixtureAdapter);
-  container.register('adapter:application', null);
+  registry.register('adapter:test', Ember.FixtureAdapter);
+  registry.register('adapter:application', null);
   var adapter = Ember.run(store, store.adapterFor, 'test');
   ok(adapter instanceof Ember.FixtureAdapter);
 });
 
 test("store.adapterFor(type) returns application adapter if no klass.adapter or type adapter", function() {
   TestModel.adapter = undefined;
-  container.register('adapter:test', null);
-  container.register('adapter:application', Ember.FixtureAdapter);
+  registry.register('adapter:test', null);
+  registry.register('adapter:application', Ember.FixtureAdapter);
   var adapter = Ember.run(store, store.adapterFor, 'test');
   ok(adapter instanceof Ember.FixtureAdapter);
 });
@@ -188,9 +189,9 @@ test("store.adapterFor(type) returns application adapter if no klass.adapter or 
 test("store.adapterFor(type) defaults to RESTAdapter if no adapter specified", function() {
 
   TestModel.adapter = undefined;
-  container.register('adapter:test', null);
-  container.register('adapter:application', null);
-  container.register('adapter:REST',  Ember.RESTAdapter);
+  registry.register('adapter:test', null);
+  registry.register('adapter:application', null);
+  registry.register('adapter:REST',  Ember.RESTAdapter);
   var adapter = Ember.run(store, store.adapterFor, 'test');
   ok(adapter instanceof Ember.RESTAdapter);
 });
@@ -199,8 +200,8 @@ test("store.find(type) records use application adapter if no klass.adapter or ty
   expect(3);
   TestModel.adapter = undefined;
   EmbeddedModel.adapter = undefined;
-  container.register('adapter:test', null);
-  container.register('adapter:application', Ember.FixtureAdapter);
+  registry.register('adapter:test', null);
+  registry.register('adapter:application', Ember.FixtureAdapter);
   
   var promise = Ember.run(store, store.find, 'test','a');
 

--- a/tests/runner.html.tmpl
+++ b/tests/runner.html.tmpl
@@ -10,14 +10,16 @@
   <div id="qunit-fixture"></div>
   <script type="text/javascript" src="../bower_components/jquery/dist/jquery.js"></script>
   <script type="text/javascript" src="../bower_components/handlebars/handlebars.js"></script>
-  <script type="text/javascript" src="../bower_components/ember/ember.js"></script>
+  <script type="text/javascript" src="../bower_components/ember/ember.debug.js"></script>
 
   <script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
 
   <script type="text/javascript" src="expect_assertion_helper.js"></script>
 
   <script type="text/javascript">
-    TESTING = true;  
+    TESTING = true;
+    // FIXME: Logging rejected promises
+    Ember.Logger.error = Ember.K;
   </script>
 
   <script src="../dist/ember-model.js"></script>


### PR DESCRIPTION
- Fixes #419 - getting computed relationship
  meta data
- Fixes Ember registry/container deprecations
  in tests
- Disable logging for rejected promises (when running tests)