### PR TITLE
Fixed Ember.set assertion error in createReference 

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -88,7 +88,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
 
     if (!reference) {
       reference = this.constructor._getOrCreateReferenceForId(id);
-      reference.record = this;
+      set(reference, 'record', this);
       this._reference = reference;
     } else if (reference.id !== id) {
       reference.id = id;


### PR DESCRIPTION
http://emberjs.com/blog/2014/10/26/ember-1-8-0-released.html#toc_breaking-changes

Ember 1.8.0 + raises errors when not using Ember.set syntax setting properties on ember objects