### PR TITLE
Compatability with Ember 1.11 and 1.12

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -30,6 +30,15 @@ function hasCachedValue(object, key) {
   }
 }
 
+function isDescriptor(value) {
+  // Ember < 1.11
+  if (Ember.Descriptor !== undefined) {
+    return value instanceof Ember.Descriptor;
+  }
+  // Ember >= 1.11
+  return value && typeof value === 'object' && value.isDescriptor;
+}
+
 Ember.run.queues.push('data');
 
 Ember.Model = Ember.Object.extend(Ember.Evented, {
@@ -141,7 +150,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   didDefineProperty: function(proto, key, value) {
-    if (value instanceof Ember.Descriptor) {
+    if (isDescriptor(value)) {
       var meta = value.meta();
       var klass = proto.constructor;
 


### PR DESCRIPTION
`Ember.Descriptor` has gone the way of the dodo in ember. This was stolen
from the ember inspector and makes everything work again. See the
following for more information:

https://github.com/emberjs/ember.js/pull/10672
https://github.com/emberjs/ember-inspector/pull/327