### PR TITLE
Uses the method from ajaxSettings instead of passed in

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -130,7 +130,7 @@ Ember.RESTAdapter = Ember.Adapter.extend({
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
       if (params) {
-        if (method === "GET") {
+        if (settings.type === "GET") {
           settings.data = params;
         } else {
           settings.contentType = "application/json; charset=utf-8";


### PR DESCRIPTION
If you override ajaxSettings and change the method/type, it was
getting ignored in _ajax(). This uses the ajaxSettings method rather
than the one passed in, giving users the ability to talk to
non-traditional APIs.