### PR TITLE
Update Ember CLI installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ EM is still a work in progress, but it's flexible and stable enough to be [used 
 
 ### Ember CLI
 
-`ember install:addon ember-model`
+`ember install ember-model`
 
 ### Bower
 


### PR DESCRIPTION
`ember install:addon` is deprecated and should simply be `ember install`.