### PR TITLE
Fix Deprecations for Ember 1.13

### DIFF
--- a/packages/ember-model/lib/has_many_array.js
+++ b/packages/ember-model/lib/has_many_array.js
@@ -70,22 +70,22 @@ Ember.ManyArray = Ember.RecordArray.extend({
     this._super(index, removed, added);
   },
 
-  _contentWillChange: function() {
-    var content = get(this, 'content');
-
-    if (content) {
-      this.arrayWillChange(content, 0, get(content, 'length'), 0);
-      content.removeArrayObserver(this);
-      this._setupOriginalContent(content);
-    }
-  }.observesBefore('content'),
-
   _contentDidChange: function() {
     var content = get(this, 'content');
+    var contentPrev = this._content;
+
+    if (contentPrev && contentPrev !== content) {
+      this.arrayWillChange(contentPrev, 0, get(contentPrev, 'length'), 0);
+      contentPrev.removeArrayObserver(this);
+      this._setupOriginalContent(content);
+    }
+
     if (content) {
       content.addArrayObserver(this);
       this.arrayDidChange(content, 0, 0, get(content, 'length'));
     }
+
+    this._content = content;
   }.observes('content'),
 
   arrayWillChange: function(item, idx, removedCnt, addedCnt) {

--- a/packages/ember-model/tests/has_many/embedded_objects_load_test.js
+++ b/packages/ember-model/tests/has_many/embedded_objects_load_test.js
@@ -31,8 +31,8 @@ test("derp", function() {
 
   equal(comments.get('length'), 3);
   ok(Ember.run(comments, comments.get, 'firstObject') instanceof Comment);
-  deepEqual(Ember.run(comments, comments.mapProperty, 'text'), ['uno', 'dos', 'tres']);
-  ok(!comments.everyProperty('isNew'), "Records should not be new");
+  deepEqual(Ember.run(comments, comments.mapBy, 'text'), ['uno', 'dos', 'tres']);
+  ok(!comments.isEvery('isNew'), "Records should not be new");
 });
 
 test("loading embedded data into a parent updates the child records", function() {

--- a/packages/ember-model/tests/has_many/embedded_objects_save_test.js
+++ b/packages/ember-model/tests/has_many/embedded_objects_save_test.js
@@ -54,7 +54,7 @@ test("derp", function() {
 
   equal(comments.get('length'), 4);
   ok(newComment instanceof Comment);
-  deepEqual(Ember.run(comments, comments.mapProperty, 'text'), ['uno', 'dos', 'tres', 'quattro']);
+  deepEqual(Ember.run(comments, comments.mapBy, 'text'), ['uno', 'dos', 'tres', 'quattro']);
 
   Ember.run(function() {
     stop();

--- a/packages/ember-model/tests/has_many/objects_load_test.js
+++ b/packages/ember-model/tests/has_many/objects_load_test.js
@@ -43,7 +43,7 @@ test("loads objects based on their ids", function() {
     start();
     equal(comments.get('length'), 3, "There are 3 comments");
     ok(Ember.run(comments, comments.get, 'firstObject') instanceof Comment, "The first object is a Comment object");
-    deepEqual(Ember.run(comments, comments.mapProperty, 'text'), ['uno', 'dos', 'tres'], "The comments are loaded");
-    ok(!comments.everyProperty('isNew'), "Records should not be new");
+    deepEqual(Ember.run(comments, comments.mapBy, 'text'), ['uno', 'dos', 'tres'], "The comments are loaded");
+    ok(!comments.isEvery('isNew'), "Records should not be new");
   });
 });


### PR DESCRIPTION
Fixes deprecations in tests and removes deprecated before observer in many-array.
Resolves #431.