### PR TITLE
Avoid crashing when setting a relationship without fetching it first

### DIFF
--- a/packages/ember-model/lib/has_many.js
+++ b/packages/ember-model/lib/has_many.js
@@ -31,6 +31,9 @@ Ember.hasMany = function(type, options) {
       return this.getHasMany(key, type, meta, this.container);
     },
     set: function(propertyKey, newContentArray, existingArray) {
+      if (!existingArray) {
+        existingArray = this.getHasMany(options.key || propertyKey, type, meta, this.container);
+      }
       return existingArray.setObjects(newContentArray);
     }
   }).meta(meta);

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -66,12 +66,16 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
 
   _relationshipBecameDirty: function(name) {
     var dirtyAttributes = get(this, '_dirtyAttributes');
-    if (!dirtyAttributes.contains(name)) { dirtyAttributes.pushObject(name); }
+    if (dirtyAttributes) {
+        dirtyAttributes.addObject(name);
+    } else {
+        set(this, '_dirtyAttributes', [name]);
+    }
   },
 
   _relationshipBecameClean: function(name) {
     var dirtyAttributes = get(this, '_dirtyAttributes');
-    dirtyAttributes.removeObject(name);
+    if (dirtyAttributes) { dirtyAttributes.removeObject(name); }
   },
 
   dataKey: function(key) {

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -146,6 +146,58 @@ test("when fetching an association getHasMany is called", function() {
   equal(article.get('comments'), 'foobar', "value returned from getHasMany should be returned as an association");
 });
 
+test("when setting an association that has been neither loaded or fetched getHasMany is called", function () {
+    expect(4);
+    var Comment = Ember.Model.extend({
+        token: Ember.attr(String)
+      }),
+      Article = Ember.Model.extend({
+        comments: Ember.hasMany(Comment, { key: 'comments', embedded: true })
+      });
+
+  Comment.primaryKey = 'token';
+
+  var article = Article.create();
+
+  article.getHasMany = function(key, type, meta) {
+    equal(key, 'comments', "key passed to getHasMany should be the same as key in hasMany options");
+    equal(type, Comment, "type of the association should be passed to getHasMany");
+    equal(meta.kind, 'hasMany', "metadata should be passed to getHasMany");
+
+    return Ember.A();
+  };
+
+  article.set('comments', Ember.A([{token: 'a'}, {token: 'b'}]));
+  deepEqual(article.get('comments'), [{token: 'a'}, {token: 'b'}], "setting the relation should have created and filled a hasManyArray");
+});
+
+test("when setting an association that has been loaded but not fetched getHasMany is called", function () {
+    expect(4);
+    var Comment = Ember.Model.extend({
+        token: Ember.attr(String)
+      }),
+      Article = Ember.Model.extend({
+        comments: Ember.hasMany(Comment, { key: 'comments', embedded: true })
+      });
+
+  Comment.primaryKey = 'token';
+
+  var article = Article.create();
+
+  article.getHasMany = function(key, type, meta) {
+    equal(key, 'comments', "key passed to getHasMany should be the same as key in hasMany options");
+    equal(type, Comment, "type of the association should be passed to getHasMany");
+    equal(meta.kind, 'hasMany', "metadata should be passed to getHasMany");
+
+    return Ember.A();
+  };
+
+  Ember.run(article, article.load, 1, {comments: Ember.A([{token: 'a'}, {token: 'b'}])});
+
+  article.set('comments', Ember.A([{token: 'b'}, {token: 'c'}]));
+  deepEqual(article.get('comments'), [{token: 'b'}, {token: 'c'}], "setting the relation should have created and filled a hasManyArray");
+});
+
 test("toJSON uses the given relationship key", function() {
   expect(1);
 


### PR DESCRIPTION
I find myself in a situation where I may set a relationship without fetching it first (overwriting it).
Unfortunately, this makes the `hasMany` property setter crash, because it does not check the `existingArray` actually exists.

As a workaround, I used to do this instead:
```js
    parent.get('children');    // trigger relationship materialization
    parent.set('children', newChildrenArray);
```

It is not very convenient, and it triggers a `findMany` request to the server, which is pointless since results will be discarded anyway. So this PR makes the property setter check the `existingArray` actually exists, and create it if it doesn't.