### PR TITLE
HasMany improvements

### DIFF
--- a/packages/ember-model/lib/has_many.js
+++ b/packages/ember-model/lib/has_many.js
@@ -34,7 +34,10 @@ Ember.hasMany = function(type, options) {
       if (!existingArray) {
         existingArray = this.getHasMany(options.key || propertyKey, type, meta, this.container);
       }
-      return existingArray.setObjects(newContentArray);
+      if (!Ember.isEqual(newContentArray, existingArray)) {
+        return existingArray.setObjects(newContentArray);
+      }
+      return existingArray;
     }
   }).meta(meta);
 };

--- a/packages/ember-model/lib/has_many_array.js
+++ b/packages/ember-model/lib/has_many_array.js
@@ -123,10 +123,19 @@ Ember.ManyArray = Ember.RecordArray.extend({
   },
 
   load: function(content) {
-    Ember.setProperties(this, {
-      content: content,
-      originalContent: content.slice()
-    });
+    var currentContent = get(this, 'content');
+    var mustUpdateCollection = content.length !== currentContent.length;
+    for (var i = 0, l = content.length; i < l && !mustUpdateCollection; i++) {
+      var existingItem = currentContent[i];
+      var newItem = content[i];
+      mustUpdateCollection = newItem !== existingItem;
+    }
+    if (mustUpdateCollection) {
+      Ember.setProperties(this, {
+        content: content,
+        originalContent: content.slice()
+        });
+    }
     set(this, '_modifiedRecords', []);
   },
 


### PR DESCRIPTION
- Setting a has many array with the same array must not trigger its observers
- Loading collections with same element twice must not trigger observers

We solved this issues in our fork to avoid a huge Ember component from being re-drawn and also prevents the collections from being dirty when there have been no changes, which means less http requests.

Thanks for the lib!
