### PR TITLE
back to Ember.merge from Ember.assign, for Ember 2.0.3 compatibility

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -122,7 +122,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
   load: function(id, hash) {
     var data = {};
     data[get(this.constructor, 'primaryKey')] = id;
-    set(this, '_data', Ember.assign(data, hash));
+    set(this, '_data', Ember.merge(data, hash));
     this.getWithDefault('_dirtyAttributes', []).clear();
 
     this._reloadHasManys();

--- a/packages/ember-model/lib/store.js
+++ b/packages/ember-model/lib/store.js
@@ -25,7 +25,7 @@ Ember.Model.Store = Ember.Object.extend({
   createRecord: function(type, props) {
     var klass = this.modelFor(type);
     klass.reopenClass({adapter: this.adapterFor(type)});
-    return klass.create(Ember.assign({container: this.container}, props));
+    return klass.create(Ember.merge({container: this.container}, props));
   },
 
   find: function(type, id) {


### PR DESCRIPTION
Starting to port some Square patches into a fork. Want to start from a green build, but travis ci (and locally) the tests fail because the bundled version of Ember doesn't have `assign`. Can we get a 0.0.18 release?