### PR TITLE
Ensure the Promise returned by `HasManyArray#save` is an Ember Array.

### DIFF
--- a/packages/ember-model/lib/has_many_array.js
+++ b/packages/ember-model/lib/has_many_array.js
@@ -59,7 +59,7 @@ Ember.ManyArray = Ember.RecordArray.extend({
     // TODO: loop over dirty records only
     return Ember.RSVP.all(this.map(function(record) {
       return record.save();
-    }));
+    })).then(Ember.A);
   },
 
   replaceContent: function(index, removed, added) {

--- a/packages/ember-model/tests/has_many/nonembedded_objects_save_test.js
+++ b/packages/ember-model/tests/has_many/nonembedded_objects_save_test.js
@@ -87,7 +87,7 @@ test("saving child objects", function() {
   var promise = Ember.run(comments, comments.save);
   promise.then(function(records) {
     start();
-    var comment = records[0];
+    var comment = records.get('firstObject');
     equal(comment.get("id"), 2, "Data from the response is loaded");
   }).catch(function(error) {
     console.error(error);


### PR DESCRIPTION
This restores the test to the old behavior of using `.get('firstObject')` and thereby ensures the array extensions are present.