### PR TITLE
Remove duplicate code for find/fetch

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -422,11 +422,11 @@ Ember.Model.reopenClass({
   },
 
   find: function(id) {
-    return _findFetch(id, false);
+    return this._findFetch(id, false);
   },
 
   fetch: function(id) {
-    return _findFetch(id, true);
+    return this._findFetch(id, true);
   },
 
   _findFetch: function(id, isFetch) {

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -439,7 +439,7 @@ Ember.Model.reopenClass({
     } else {
       return this._findFetchById(id, isFetch);
     }
-  }
+  },
 
   findQuery: function(params) {
     return this._findFetchQuery(params, false);

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -421,29 +421,25 @@ Ember.Model.reopenClass({
     return relationships;
   },
 
-  fetch: function(id) {
-    if (!arguments.length) {
-      return this._findFetchAll(true);
-    } else if (Ember.isArray(id)) {
-      return this._findFetchMany(id, true);
-    } else if (typeof id === 'object') {
-      return this._findFetchQuery(id, true);
-    } else {
-      return this._findFetchById(id, true);
-    }
+  find: function(id) {
+    return _findFetch(id, false);
   },
 
-  find: function(id) {
-    if (!arguments.length) {
-      return this._findFetchAll(false);
-    } else if (Ember.isArray(id)) {
-      return this._findFetchMany(id, false);
-    } else if (typeof id === 'object') {
-      return this._findFetchQuery(id, false);
-    } else {
-      return this._findFetchById(id, false);
-    }
+  fetch: function(id) {
+    return _findFetch(id, true);
   },
+
+  _findFetch: function(id, isFetch) {
+    if (!arguments.length) {
+      return this._findFetchAll(isFetch);
+    } else if (Ember.isArray(id)) {
+      return this._findFetchMany(id, isFetch);
+    } else if (typeof id === 'object') {
+      return this._findFetchQuery(id, isFetch);
+    } else {
+      return this._findFetchById(id, isFetch);
+    }
+  }
 
   findQuery: function(params) {
     return this._findFetchQuery(params, false);


### PR DESCRIPTION
Adds a _findFetch function in the same vein as the other _findFetch[...] functions to reduce duplicate code, and puts them in the same order (find then fetch) as the others.