### PR TITLE
Rename store and adapter for Ember Data compatibility

### DIFF
--- a/ember-model.js
+++ b/ember-model.js
@@ -1418,9 +1418,9 @@ function getType(record) {
     this.type = get(Ember.lookup, this.type);
 
     if (!this.type) {
-      var store = record.container.lookup('store:main');
-      this.type = store.modelFor(type);
-      this.type.reopenClass({ adapter: store.adapterFor(type) });
+      var emstore = record.container.lookup('emstore:main');
+      this.type = emstore.modelFor(type);
+      this.type.reopenClass({ adapter: emstore.adapterFor(type) });
     }
   }
 
@@ -1480,7 +1480,7 @@ var get = Ember.get,
 
 function storeFor(record) {
   if (record.container) {
-    return record.container.lookup('store:main');
+    return record.container.lookup('emstore:main');
   }
 
   return null;
@@ -1493,9 +1493,9 @@ function getType(record) {
     type = Ember.get(Ember.lookup, this.type);
 
     if (!type) {
-      var store = storeFor(record);
-      type = store.modelFor(this.type);
-      type.reopenClass({ adapter: store.adapterFor(this.type) });
+      var emstore = storeFor(record);
+      type = emstore.modelFor(this.type);
+      type.reopenClass({ adapter: emstore.adapterFor(this.type) });
     }
   }
 
@@ -1523,8 +1523,8 @@ Ember.belongsTo = function(type, options) {
         }
       };
 
-      var store = storeFor(this),
-          value = this.getBelongsTo(key, type, meta, store);
+      var emstore = storeFor(this),
+          value = this.getBelongsTo(key, type, meta, emstore);
       this._registerBelongsTo(meta);
       if (value !== null && meta.options.embedded) {
         value.get('isDirty'); // getter must be called before adding observer
@@ -1583,7 +1583,7 @@ Ember.belongsTo = function(type, options) {
 };
 
 Ember.Model.reopen({
-  getBelongsTo: function(key, type, meta, store) {
+  getBelongsTo: function(key, type, meta, emstore) {
     var idOrAttrs = get(this, '_data.' + key),
         record;
 
@@ -1597,8 +1597,8 @@ Ember.Model.reopen({
       record = type.create({ isLoaded: false, id: id, container: this.container });
       record.load(id, idOrAttrs);
     } else {
-      if (store) {
-        record = store._findSync(meta.type, idOrAttrs);
+      if (emstore) {
+        record = emstore._findSync(meta.type, idOrAttrs);
       } else {
         record = type.find(idOrAttrs);
       }
@@ -2036,11 +2036,11 @@ var DebugAdapter = Ember.DataAdapter.extend({
 
 Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
-    name: "data-adapter",
+    name: "em-data-adapter",
 
     initialize: function() {
       var application = arguments[1] || arguments[0];
-      application.register('data-adapter:main', DebugAdapter);
+      application.register('em-data-adapter:main', DebugAdapter);
     }
   });
 });
@@ -2111,16 +2111,16 @@ Ember.Model.Store = Ember.Object.extend({
 Ember.onLoad('Ember.Application', function(Application) {
 
   Application.initializer({
-    name: "store",
+    name: "emstore",
 
     initialize: function() {
       var application = arguments[1] || arguments[0];
-      var store = application.Store || Ember.Model.Store;
-      application.register('store:application', store);
-      application.register('store:main', store);
+      var emstore = application.Store || Ember.Model.Store;
+      application.register('emstore:application', emstore);
+      application.register('emstore:main', emstore);
 
-      application.inject('route', 'store', 'store:main');
-      application.inject('controller', 'store', 'store:main');
+      application.inject('route', 'emstore', 'emstore:main');
+      application.inject('controller', 'emstore', 'emstore:main');
     }
   });
 

--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -4,7 +4,7 @@ var get = Ember.get,
 
 function storeFor(record) {
   if (record.container) {
-    return record.container.lookup('store:main');
+    return record.container.lookup('emstore:main');
   }
 
   return null;
@@ -17,9 +17,9 @@ function getType(record) {
     type = Ember.get(Ember.lookup, this.type);
 
     if (!type) {
-      var store = storeFor(record);
-      type = store.modelFor(this.type);
-      type.reopenClass({ adapter: store.adapterFor(this.type) });
+      var emstore = storeFor(record);
+      type = emstore.modelFor(this.type);
+      type.reopenClass({ adapter: emstore.adapterFor(this.type) });
     }
   }
 
@@ -47,8 +47,8 @@ Ember.belongsTo = function(type, options) {
         }
       };
 
-      var store = storeFor(this),
-          value = this.getBelongsTo(key, type, meta, store);
+      var emstore = storeFor(this),
+          value = this.getBelongsTo(key, type, meta, emstore);
       this._registerBelongsTo(meta);
       if (value !== null && meta.options.embedded) {
         value.get('isDirty'); // getter must be called before adding observer
@@ -107,7 +107,7 @@ Ember.belongsTo = function(type, options) {
 };
 
 Ember.Model.reopen({
-  getBelongsTo: function(key, type, meta, store) {
+  getBelongsTo: function(key, type, meta, emstore) {
     var idOrAttrs = get(this, '_data.' + key),
         record;
 
@@ -121,8 +121,8 @@ Ember.Model.reopen({
       record = type.create({ isLoaded: false, id: id, container: this.container });
       record.load(id, idOrAttrs);
     } else {
-      if (store) {
-        record = store._findSync(meta.type, idOrAttrs);
+      if (emstore) {
+        record = emstore._findSync(meta.type, idOrAttrs);
       } else {
         record = type.find(idOrAttrs);
       }

--- a/packages/ember-model/lib/debug_adapter.js
+++ b/packages/ember-model/lib/debug_adapter.js
@@ -105,11 +105,11 @@ var DebugAdapter = Ember.DataAdapter.extend({
 
 Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
-    name: "data-adapter",
+    name: "em-data-adapter",
 
     initialize: function() {
       var application = arguments[1] || arguments[0];
-      application.register('data-adapter:main', DebugAdapter);
+      application.register('em-data-adapter:main', DebugAdapter);
     }
   });
 });

--- a/packages/ember-model/lib/has_many.js
+++ b/packages/ember-model/lib/has_many.js
@@ -8,9 +8,9 @@ function getType(record) {
     this.type = get(Ember.lookup, this.type);
 
     if (!this.type) {
-      var store = record.container.lookup('store:main');
-      this.type = store.modelFor(type);
-      this.type.reopenClass({ adapter: store.adapterFor(type) });
+      var emstore = record.container.lookup('emstore:main');
+      this.type = emstore.modelFor(type);
+      this.type.reopenClass({ adapter: emstore.adapterFor(type) });
     }
   }
 

--- a/packages/ember-model/lib/store.js
+++ b/packages/ember-model/lib/store.js
@@ -59,16 +59,16 @@ Ember.Model.Store = Ember.Object.extend({
 Ember.onLoad('Ember.Application', function(Application) {
 
   Application.initializer({
-    name: "store",
+    name: "emstore",
 
     initialize: function() {
       var application = arguments[1] || arguments[0];
       var store = application.Store || Ember.Model.Store;
-      application.register('store:application', store);
-      application.register('store:main', store);
+      application.register('emstore:application', store);
+      application.register('emstore:main', store);
 
-      application.inject('route', 'store', 'store:main');
-      application.inject('controller', 'store', 'store:main');
+      application.inject('route', 'emstore', 'emstore:main');
+      application.inject('controller', 'emstore', 'emstore:main');
     }
   });
 

--- a/packages/ember-model/tests/store_test.js
+++ b/packages/ember-model/tests/store_test.js
@@ -1,11 +1,11 @@
-var TestModel, EmbeddedModel, UUIDModel, store, registry, container, App;
+var TestModel, EmbeddedModel, UUIDModel, emstore, registry, container, App;
 
 module("Ember.Model.Store", {
   setup: function() {
     registry = new Ember.Registry();
     container = registry.container();
 
-    store = Ember.Model.Store.create({container: container});
+    emstore = Ember.Model.Store.create({container: container});
     TestModel = Ember.Model.extend({
       token: Ember.attr(),
       name: Ember.attr(),
@@ -64,26 +64,26 @@ module("Ember.Model.Store", {
     registry.register('model:test', TestModel);
     registry.register('model:embedded', EmbeddedModel);
     registry.register('model:uuid', UUIDModel);
-    registry.register('store:main', Ember.Model.Store);
+    registry.register('emstore:main', Ember.Model.Store);
   }
 });
 
-test("store.createRecord(type) returns a record with a container", function() {
-  var record = Ember.run(store, store.createRecord, 'test');
+test("emstore.createRecord(type) returns a record with a container", function() {
+  var record = Ember.run(emstore, emstore.createRecord, 'test');
   equal(record.container, container);
   equal(record.container, container);
 });
 
-test("store.createRecord(type) with properties", function() {
+test("emstore.createRecord(type) with properties", function() {
   expect(2);
-  var record = Ember.run(store, store.createRecord, 'test', {token: 'c', name: 'Andrew'});
+  var record = Ember.run(emstore, emstore.createRecord, 'test', {token: 'c', name: 'Andrew'});
   equal(record.get('token'), 'c');
   equal(record.get('name'), 'Andrew');
 });
 
 test("model.load(hashes) returns a existing record with correct container", function() {
-  var model = store.modelFor('uuid'),
-      record = Ember.run(store, store.createRecord, 'uuid');
+  var model = emstore.modelFor('uuid'),
+      record = Ember.run(emstore, emstore.createRecord, 'uuid');
 
   equal(model, UUIDModel);
   equal(record.container, container);
@@ -108,9 +108,9 @@ test("model.load(hashes) returns a existing record with correct container", func
   equal(record.get('container'), container);
 });
 
-test("store.find(type) returns a record with hasMany and belongsTo that should all have a container", function() {
+test("emstore.find(type) returns a record with hasMany and belongsTo that should all have a container", function() {
   expect(4);
-  var promise = Ember.run(store, store.find, 'test', 'a');
+  var promise = Ember.run(emstore, emstore.find, 'test', 'a');
   promise.then(function(record) {
     start();
     ok(record.get('container'));
@@ -123,10 +123,10 @@ test("store.find(type) returns a record with hasMany and belongsTo that should a
   stop();
 });
 
-test("store.find(type, id) returns a promise and loads a container for the record", function() {
+test("emstore.find(type, id) returns a promise and loads a container for the record", function() {
   expect(2);
 
-  var promise = Ember.run(store, store.find, 'test','a');
+  var promise = Ember.run(emstore, emstore.find, 'test','a');
   promise.then(function(record) {
     start();
     ok(record.get('isLoaded'));
@@ -135,10 +135,10 @@ test("store.find(type, id) returns a promise and loads a container for the recor
   stop();
 });
 
-test("store.find(type) returns a promise and loads a container for each record", function() {
+test("emstore.find(type) returns a promise and loads a container for each record", function() {
   expect(5);
 
-  var promise = Ember.run(store, store.find, 'test');
+  var promise = Ember.run(emstore, emstore.find, 'test');
   promise.then(function(records) {
     start();
     equal(records.content.length, 2);
@@ -150,10 +150,10 @@ test("store.find(type) returns a promise and loads a container for each record",
   stop();
 });
 
-test("store.find(type, Array) returns a promise and loads a container for each record", function() {
+test("emstore.find(type, Array) returns a promise and loads a container for each record", function() {
   expect(5);
 
-  var promise = Ember.run(store, store.find, 'test', ['a','b']);
+  var promise = Ember.run(emstore, emstore.find, 'test', ['a','b']);
   promise.then(function(records) {
     start();
     equal(records.content.length, 2);
@@ -165,45 +165,45 @@ test("store.find(type, Array) returns a promise and loads a container for each r
   stop();
 });
 
-test("store.adapterFor(type) returns klass.adapter first", function() {
-  var adapter = Ember.run(store, store.adapterFor, 'test');
+test("emstore.adapterFor(type) returns klass.adapter first", function() {
+  var adapter = Ember.run(emstore, emstore.adapterFor, 'test');
   equal(adapter.constructor, Ember.FixtureAdapter);
 });
 
-test("store.adapterFor(type) returns type adapter if no klass.adapter", function() {
+test("emstore.adapterFor(type) returns type adapter if no klass.adapter", function() {
   TestModel.adapter = undefined;
   registry.register('adapter:test', Ember.FixtureAdapter);
   registry.register('adapter:application', null);
-  var adapter = Ember.run(store, store.adapterFor, 'test');
+  var adapter = Ember.run(emstore, emstore.adapterFor, 'test');
   ok(adapter instanceof Ember.FixtureAdapter);
 });
 
-test("store.adapterFor(type) returns application adapter if no klass.adapter or type adapter", function() {
+test("emstore.adapterFor(type) returns application adapter if no klass.adapter or type adapter", function() {
   TestModel.adapter = undefined;
   registry.register('adapter:test', null);
   registry.register('adapter:application', Ember.FixtureAdapter);
-  var adapter = Ember.run(store, store.adapterFor, 'test');
+  var adapter = Ember.run(emstore, emstore.adapterFor, 'test');
   ok(adapter instanceof Ember.FixtureAdapter);
 });
 
-test("store.adapterFor(type) defaults to RESTAdapter if no adapter specified", function() {
+test("emstore.adapterFor(type) defaults to RESTAdapter if no adapter specified", function() {
 
   TestModel.adapter = undefined;
   registry.register('adapter:test', null);
   registry.register('adapter:application', null);
   registry.register('adapter:REST',  Ember.RESTAdapter);
-  var adapter = Ember.run(store, store.adapterFor, 'test');
+  var adapter = Ember.run(emstore, emstore.adapterFor, 'test');
   ok(adapter instanceof Ember.RESTAdapter);
 });
 
-test("store.find(type) records use application adapter if no klass.adapter or type adapter", function() {
+test("emstore.find(type) records use application adapter if no klass.adapter or type adapter", function() {
   expect(3);
   TestModel.adapter = undefined;
   EmbeddedModel.adapter = undefined;
   registry.register('adapter:test', null);
   registry.register('adapter:application', Ember.FixtureAdapter);
 
-  var promise = Ember.run(store, store.find, 'test','a');
+  var promise = Ember.run(emstore, emstore.find, 'test','a');
 
   promise.then(function(record) {
     start();
@@ -225,11 +225,11 @@ test("Registering a custom store on application works", function() {
   });
 
   container = App.__container__;
-  ok(container.lookup('store:application'));
-  ok(container.lookup('store:main').get('custom'));
+  ok(container.lookup('emstore:application'));
+  ok(container.lookup('emstore:main').get('custom'));
 
   var testRoute = container.lookup('route:test');
-  ok(testRoute.get('store.custom'));
+  ok(testRoute.get('emstore.custom'));
 
   Ember.run(App, 'destroy');
 });


### PR DESCRIPTION
@intercom we're using both Ember Model and Ember Data in production. We're in the process of migrating fully to Ember Data. While that migration is happening, we have renamed the Ember Model store and data adapter to allow us to use both addons simultaneously as they conflict otherwise.

In this PR we've renamed `store` to `emstore` and `data-adapter` to `em-data-adapter`.

@ebryn This is a breaking change, but it might be something for you to consider. It opens a path for people to move to Ember Data without having to rewrite all their models at once. Let me know your thoughts. 🙂 