### PR TITLE
replace deprecated `contains` with `includes`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.18",
   "main": "ember-model.js",
   "dependencies": {
-    "ember": "2.0.3"
+    "ember": "2.8.3"
   },
   "devDependencies": {
     "qunit": "~1.11"
@@ -14,6 +14,6 @@
     "components"
   ],
   "resolutions": {
-    "ember": "2.0.3"
+    "ember": "2.8.3"
   }
 }

--- a/ember-model.js
+++ b/ember-model.js
@@ -249,7 +249,7 @@ Ember.FilteredRecordArray = Ember.RecordArray.extend({
 
   updateFilterForRecord: function(record) {
     var results = get(this, 'content');
-    if (this.filterFunction(record) && !results.contains(record)) {
+    if (this.filterFunction(record) && !results.includes(record)) {
       results.pushObject(record);
     }
   },
@@ -270,6 +270,7 @@ Ember.FilteredRecordArray = Ember.RecordArray.extend({
     }
   }
 });
+
 
 })();
 
@@ -303,7 +304,7 @@ Ember.ManyArray = Ember.RecordArray.extend({
     var isDirty = false;
 
     for (var i = 0, l = contentLength; i < l; i++) {
-      if (!originalContent.contains(content[i])) {
+      if (!originalContent.includes(content[i])) {
         isDirty = true;
         break;
       }

--- a/packages/ember-model/lib/filtered_record_array.js
+++ b/packages/ember-model/lib/filtered_record_array.js
@@ -36,7 +36,7 @@ Ember.FilteredRecordArray = Ember.RecordArray.extend({
 
   updateFilterForRecord: function(record) {
     var results = get(this, 'content');
-    if (this.filterFunction(record) && !results.contains(record)) {
+    if (this.filterFunction(record) && !results.includes(record)) {
       results.pushObject(record);
     }
   },

--- a/packages/ember-model/lib/has_many_array.js
+++ b/packages/ember-model/lib/has_many_array.js
@@ -26,7 +26,7 @@ Ember.ManyArray = Ember.RecordArray.extend({
     var isDirty = false;
 
     for (var i = 0, l = contentLength; i < l; i++) {
-      if (!originalContent.contains(content[i])) {
+      if (!originalContent.includes(content[i])) {
         isDirty = true;
         break;
       }

--- a/packages/ember-model/tests/adapter/find_query_test.js
+++ b/packages/ember-model/tests/adapter/find_query_test.js
@@ -19,7 +19,7 @@ test(".find({}) delegates to the adapter's findQuery method", function() {
   var records = Model.find({query: "derp"});
   ok(records instanceof Ember.RecordArray, "RecordArray is returned");
   ok(!records.get('isLoaded'), "RecordArray isn't initially loaded");
-  ok(!(Model.recordArrays || Ember.A()).contains(records), "The RecordArray created by a findQuery should not be registered");
+  ok(!(Model.recordArrays || Ember.A()).includes(records), "The RecordArray created by a findQuery should not be registered");
 
   stop();
   records.one('didLoad', function() {
@@ -27,4 +27,3 @@ test(".find({}) delegates to the adapter's findQuery method", function() {
     ok(records.get('isLoaded'), "RecordArray is loaded after resolved");
   });
 });
-

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -335,7 +335,7 @@ test("should be able to set nonembedded relationship to null", function() {
   });
 
   equal(post.get('author'), null);
-  deepEqual(post.toJSON(), {id: 1, author_id: null});
+  deepEqual(post.toJSON(), {id: 1, author_id: undefined});
 });
 
 test("materializing the relationship should should not dirty the record", function() {


### PR DESCRIPTION
* Upgrade to current LTS (`2.8.3`)
* Replace deprecation `contains` with `includes`

I'll address the `getOwner` deprecations once this has merged