### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 ---
 language: node_js
+node_js:
+  - "6"
+  - "8"
 before_script:
 - npm install grunt-cli bower
 - bower install

--- a/bower.json
+++ b/bower.json
@@ -12,8 +12,5 @@
     "**/.*",
     "node_modules",
     "components"
-  ],
-  "resolutions": {
-    "ember": "2.8.3"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   "author": "no",
   "license": "MIT",
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-neuter": "~0.5.0",
+    "grunt": "~1.0.1",
+    "grunt-neuter": "~0.6.0",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-uglify": "~0.2.2",
-    "grunt-contrib-qunit": "~0.2.2",
+    "grunt-contrib-qunit": "~1.3.0",
     "grunt-contrib-clean": "~0.4.1",
     "grunt-strip-node": "~0.1.1",
     "matchdep": "~0.1.2",
@@ -30,7 +30,8 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-connect": "~0.3.0",
     "grunt-contrib-watch": "~0.4.4",
-    "grunt-ember-s3": "~1.0.2"
+    "grunt-ember-s3": "~1.0.2",
+    "phantomjs-prebuilt": "~2.1.7"
   },
   "version": "0.0.18"
 }


### PR DESCRIPTION
This is the first step in getting ember-model ready for Ember 3.0.

Before upgrading these dependencies, I got the following error message when running `grunt test`:

```
Running "qunit:cli" (qunit) task
Testing tests/index.html
Running PhantomJS...ERROR
>> 0 [ '' ]
Warning: PhantomJS exited unexpectedly with exit code null. Use --force to continue.
```

The tests run (with deprecation warnings) and pass with the changes in the PR:

```
.OK
>> 228 tests completed with 0 failed, 0 skipped, and 0 todo.
>> 654 assertions (in 2640ms), passed: 654, failed: 0

Running "clean:test" (clean) task
Cleaning "tests/index.html"...OK
```

TODO:

 * [x] investigate CI failure

/cc @patocallaghan