### PR TITLE
Update grunt-contrib-watch to fix grunt.util._.contains error

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "glob": "~3.2.1",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-connect": "~0.3.0",
-    "grunt-contrib-watch": "~0.4.4",
+    "grunt-contrib-watch": "~1.0.0",
     "grunt-ember-s3": "~1.0.2",
     "phantomjs-prebuilt": "~2.1.7"
   },


### PR DESCRIPTION
Fixes rebuilding on the `grunt develop` command.

Part of https://github.com/ebryn/ember-model/pull/461

/cc @GavinJoyce 