### PR TITLE
Rename store and adapter

### DIFF
--- a/ember-model.js
+++ b/ember-model.js
@@ -1419,9 +1419,9 @@ function getType(record) {
     this.type = get(Ember.lookup, this.type);
 
     if (!this.type) {
-      var store = record.container.lookup('store:main');
-      this.type = store.modelFor(type);
-      this.type.reopenClass({ adapter: store.adapterFor(type) });
+      var emstore = record.container.lookup('emstore:main');
+      this.type = emstore.modelFor(type);
+      this.type.reopenClass({ adapter: emstore.adapterFor(type) });
     }
   }
 
@@ -1481,7 +1481,7 @@ var get = Ember.get,
 
 function storeFor(record) {
   if (record.container) {
-    return record.container.lookup('store:main');
+    return record.container.lookup('emstore:main');
   }
 
   return null;
@@ -1494,9 +1494,9 @@ function getType(record) {
     type = Ember.get(Ember.lookup, this.type);
 
     if (!type) {
-      var store = storeFor(record);
-      type = store.modelFor(this.type);
-      type.reopenClass({ adapter: store.adapterFor(this.type) });
+      var emstore = storeFor(record);
+      type = emstore.modelFor(this.type);
+      type.reopenClass({ adapter: emstore.adapterFor(this.type) });
     }
   }
 
@@ -1524,8 +1524,8 @@ Ember.belongsTo = function(type, options) {
         }
       };
 
-      var store = storeFor(this),
-          value = this.getBelongsTo(key, type, meta, store);
+      var emstore = storeFor(this),
+          value = this.getBelongsTo(key, type, meta, emstore);
       this._registerBelongsTo(meta);
       if (value !== null && meta.options.embedded) {
         value.get('isDirty'); // getter must be called before adding observer
@@ -1584,7 +1584,7 @@ Ember.belongsTo = function(type, options) {
 };
 
 Ember.Model.reopen({
-  getBelongsTo: function(key, type, meta, store) {
+  getBelongsTo: function(key, type, meta, emstore) {
     var idOrAttrs = get(this, '_data.' + key),
         record;
 
@@ -1598,8 +1598,8 @@ Ember.Model.reopen({
       record = type.create({ isLoaded: false, id: id, container: this.container });
       record.load(id, idOrAttrs);
     } else {
-      if (store) {
-        record = store._findSync(meta.type, idOrAttrs);
+      if (emstore) {
+        record = emstore._findSync(meta.type, idOrAttrs);
       } else {
         record = type.find(idOrAttrs);
       }
@@ -2037,11 +2037,11 @@ var DebugAdapter = Ember.DataAdapter.extend({
 
 Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
-    name: "data-adapter",
+    name: "em-data-adapter",
 
     initialize: function() {
       var application = arguments[1] || arguments[0];
-      application.register('data-adapter:main', DebugAdapter);
+      application.register('em-data-adapter:main', DebugAdapter);
     }
   });
 });
@@ -2112,16 +2112,16 @@ Ember.Model.Store = Ember.Object.extend({
 Ember.onLoad('Ember.Application', function(Application) {
 
   Application.initializer({
-    name: "store",
+    name: "emstore",
 
     initialize: function() {
       var application = arguments[1] || arguments[0];
-      var store = application.Store || Ember.Model.Store;
-      application.register('store:application', store);
-      application.register('store:main', store);
+      var emstore = application.Store || Ember.Model.Store;
+      application.register('emstore:application', emstore);
+      application.register('emstore:main', emstore);
 
-      application.inject('route', 'store', 'store:main');
-      application.inject('controller', 'store', 'store:main');
+      application.inject('route', 'emstore', 'emstore:main');
+      application.inject('controller', 'emstore', 'emstore:main');
     }
   });
 

--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -4,7 +4,7 @@ var get = Ember.get,
 
 function storeFor(record) {
   if (record.container) {
-    return record.container.lookup('store:main');
+    return record.container.lookup('emstore:main');
   }
 
   return null;
@@ -17,9 +17,9 @@ function getType(record) {
     type = Ember.get(Ember.lookup, this.type);
 
     if (!type) {
-      var store = storeFor(record);
-      type = store.modelFor(this.type);
-      type.reopenClass({ adapter: store.adapterFor(this.type) });
+      var emstore = storeFor(record);
+      type = emstore.modelFor(this.type);
+      type.reopenClass({ adapter: emstore.adapterFor(this.type) });
     }
   }
 
@@ -47,8 +47,8 @@ Ember.belongsTo = function(type, options) {
         }
       };
 
-      var store = storeFor(this),
-          value = this.getBelongsTo(key, type, meta, store);
+      var emstore = storeFor(this),
+          value = this.getBelongsTo(key, type, meta, emstore);
       this._registerBelongsTo(meta);
       if (value !== null && meta.options.embedded) {
         value.get('isDirty'); // getter must be called before adding observer
@@ -107,7 +107,7 @@ Ember.belongsTo = function(type, options) {
 };
 
 Ember.Model.reopen({
-  getBelongsTo: function(key, type, meta, store) {
+  getBelongsTo: function(key, type, meta, emstore) {
     var idOrAttrs = get(this, '_data.' + key),
         record;
 
@@ -121,8 +121,8 @@ Ember.Model.reopen({
       record = type.create({ isLoaded: false, id: id, container: this.container });
       record.load(id, idOrAttrs);
     } else {
-      if (store) {
-        record = store._findSync(meta.type, idOrAttrs);
+      if (emstore) {
+        record = emstore._findSync(meta.type, idOrAttrs);
       } else {
         record = type.find(idOrAttrs);
       }

--- a/packages/ember-model/lib/debug_adapter.js
+++ b/packages/ember-model/lib/debug_adapter.js
@@ -105,11 +105,11 @@ var DebugAdapter = Ember.DataAdapter.extend({
 
 Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
-    name: "data-adapter",
+    name: "em-data-adapter",
 
     initialize: function() {
       var application = arguments[1] || arguments[0];
-      application.register('data-adapter:main', DebugAdapter);
+      application.register('em-data-adapter:main', DebugAdapter);
     }
   });
 });

--- a/packages/ember-model/lib/has_many.js
+++ b/packages/ember-model/lib/has_many.js
@@ -8,9 +8,9 @@ function getType(record) {
     this.type = get(Ember.lookup, this.type);
 
     if (!this.type) {
-      var store = record.container.lookup('store:main');
-      this.type = store.modelFor(type);
-      this.type.reopenClass({ adapter: store.adapterFor(type) });
+      var emstore = record.container.lookup('emstore:main');
+      this.type = emstore.modelFor(type);
+      this.type.reopenClass({ adapter: emstore.adapterFor(type) });
     }
   }
 

--- a/packages/ember-model/lib/store.js
+++ b/packages/ember-model/lib/store.js
@@ -59,16 +59,16 @@ Ember.Model.Store = Ember.Object.extend({
 Ember.onLoad('Ember.Application', function(Application) {
 
   Application.initializer({
-    name: "store",
+    name: "emstore",
 
     initialize: function() {
       var application = arguments[1] || arguments[0];
       var store = application.Store || Ember.Model.Store;
-      application.register('store:application', store);
-      application.register('store:main', store);
+      application.register('emstore:application', store);
+      application.register('emstore:main', store);
 
-      application.inject('route', 'store', 'store:main');
-      application.inject('controller', 'store', 'store:main');
+      application.inject('route', 'emstore', 'emstore:main');
+      application.inject('controller', 'emstore', 'emstore:main');
     }
   });
 

--- a/packages/ember-model/tests/store_test.js
+++ b/packages/ember-model/tests/store_test.js
@@ -64,7 +64,7 @@ QUnit.module("Ember.Model.Store", {
     registry.register('model:test', TestModel);
     registry.register('model:embedded', EmbeddedModel);
     registry.register('model:uuid', UUIDModel);
-    registry.register('store:main', Ember.Model.Store);
+    registry.register('emstore:main', Ember.Model.Store);
   }
 });
 
@@ -224,11 +224,11 @@ QUnit.test("Registering a custom store on application works", function(assert) {
   });
 
   container = App.__container__;
-  assert.ok(container.lookup('store:application'));
-  assert.ok(container.lookup('store:main').get('custom'));
+  assert.ok(container.lookup('emstore:application'));
+  assert.ok(container.lookup('emstore:main').get('custom'));
 
   var testRoute = container.lookup('route:test');
-  assert.ok(testRoute.get('store.custom'));
+  assert.ok(testRoute.get('emstore.custom'));
 
   Ember.run(App, 'destroy');
 });


### PR DESCRIPTION
extracted from https://github.com/ebryn/ember-model/pull/454 and rebased
part of https://github.com/ebryn/ember-model/issues/462

This PR allows ember-model and ember-data to coexist. We've been running these changes in our production app in Intercom for 12 months without issue: https://github.com/intercom/ember-model/pull/7

This change brings breaking changes:

 * https://github.com/ebryn/ember-model/pull/454#issuecomment-276960712
 * https://github.com/ebryn/ember-model/pull/454#issuecomment-277091939

I think we should accept these breaking changes and release a new major version. We're close to [upgrading ember-model to Ember 2.18.2](https://github.com/ebryn/ember-model/pull/473) so I think this will be a good opportunity to release a `2.18.0` version of ember-model which will contain both changes. We can then follow up with a `3.0` release which will bring compatibility with Ember 3. 

/cc @eventualbuddha 
/cc @nolaneo as this is your work

