### PR TITLE
remove strip task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,6 @@ module.exports = function(grunt) {
       all: ['packages/ember-model/tests/**/*_test.js']
     },
     banner: config('banner'),
-    strip: config('strip'),
     clean: config('clean'),
     copy:  config('copy'),
     'ember-s3': config('ember-s3')
@@ -35,7 +34,7 @@ module.exports = function(grunt) {
   grunt.registerTask('develop', ['dev_build', 'testem:run:default']);
   grunt.registerTask('build', ['jshint:all', 'neuter', 'production']);
 
-  grunt.registerTask('production', ['copy:production', 'strip:production', 'uglify:production', 'banner']);
+  grunt.registerTask('production', ['copy:production', 'uglify:production', 'banner']);
   grunt.registerTask('test', ['jshint:all', 'neuter', 'build_test_runner_file', 'testem:ci:default', 'clean:test']);
   grunt.registerTask('default', ['build']);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -427,7 +427,7 @@
     },
     "compression": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.0.7.tgz",
       "integrity": "sha1-/Ev/Jh3043oTAAby2yqZo0iW9Vo=",
       "dev": true,
       "requires": {

--- a/tasks/options/strip.js
+++ b/tasks/options/strip.js
@@ -1,9 +1,0 @@
-module.exports = {
-  production : {
-    src : 'dist/ember-model.prod.js',
-    options : {
-      inline: true,
-      nodes : ['Ember.assert']
-    }
-  }
-};


### PR DESCRIPTION
This doesn't seem to have worked for quite a while, the [`Ember.assert` statements are currently in the production build](https://github.com/ebryn/ember-model/blob/f6ff799ee27007c006d10bb9e43e09c45ab8f302/ember-model.js#L986)

We also currently get an error when running `grunt`:

<img width="557" alt="screen shot 2018-04-16 at 09 23 48" src="https://user-images.githubusercontent.com/2526/38797974-236aa45e-4158-11e8-9863-e6702226f9c7.png">

We plan to migrate to ember-cli in the near future, so I propose that we just rip this out for now

/cc @patocallaghan
