### PR TITLE
Use the default public NPM registry.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry = "https://registry.npmjs.org"


### PR DESCRIPTION
For when a private registry is used by default on a machine and we'd like to avoid that host ending up in package-lock.json.