### PR TITLE
Upgrade Ember Model to work with Ember 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,19 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  # we recommend testing addons with the same minimum supported node version as Ember CLI
+  # so that your addon works for all apps
+  - "8"
 
-sudo: false
-dist: trusty
-
+sudo: required
 addons:
   chrome: stable
-
-cache:
-  directories:
-    - $HOME/.npm
 
 before_script:
 - npm install grunt-cli bower
 - bower install
+- export DISPLAY=:99.0
+# - sh -e /etc/init.d/xvfb start
 script: grunt test
 
 after_success: 'grunt build ember-s3'

--- a/package.json
+++ b/package.json
@@ -1,38 +1,68 @@
 {
   "name": "ember-model",
   "description": "A lightweight model library for Ember.js",
-  "main": "Gruntfile.js",
+
+  "repository": "",
+  "license": "MIT",
+  "author": "",
   "directories": {
     "test": "tests"
   },
   "scripts": {
-    "test": "grunt test"
+    "build": "ember build",
+    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
+    "start": "ember serve",
+    "test": "ember try:each"
   },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/ebryn/ember-model.git"
+  "dependencies": {
+    "broccoli-funnel": "1.1.0",
+    "broccoli-merge-trees": "^2.0.0",
+    "ember-cli-babel": "^6.6.0"
   },
   "author": "no",
   "license": "MIT",
   "devDependencies": {
-    "ember-source": "3.0.0",
-    "glob": "~3.2.1",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-ajax": "^3.0.0",
+    "ember-cli": "~3.0.4",
+    "ember-cli-dependency-checker": "^2.0.0",
+    "ember-cli-eslint": "^4.2.1",
+    "ember-cli-htmlbars": "^2.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-qunit": "^4.1.1",
+    "ember-cli-shims": "^1.2.0",
+    "ember-cli-sri": "^2.1.0",
+    "ember-cli-uglify": "^2.0.0",
+    "ember-disable-prototype-extensions": "^1.1.2",
+    "ember-export-application-global": "^2.0.0",
+    "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-resolver": "^4.0.0",
+    "ember-source": "~3.2.2",
+    "ember-source-channel-url": "^1.0.1",
+    "ember-try": "^0.2.23",
+    "ember-welcome-page": "^3.0.0",
+    "eslint-plugin-ember": "^5.0.0",
+    "eslint-plugin-node": "^6.0.1",
     "grunt": "~1.0.1",
-    "grunt-contrib-clean": "~0.4.1",
-    "grunt-contrib-connect": "~0.3.0",
-    "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt-contrib-uglify": "~0.2.2",
+    "grunt-neuter": "~0.6.0",
+    "grunt-contrib-jshint": "~1.1.0",
+    "grunt-contrib-uglify": "~2.0.0",
+    "grunt-contrib-qunit": "3.0.1",
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt-strip-node": "~0.1.1",
+    "matchdep": "~1.0.1",
+    "grunt-curl": "~2.2.0",
+    "grunt-strip": "~0.2.1",
+    "grunt-release": "~0.14.0",
+    "glob": "4.4.2",
+    "grunt-contrib-copy": "~1.0.0",
+    "grunt-contrib-connect": "~1.0.2",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-curl": "~1.1.1",
     "grunt-ember-s3": "~1.0.2",
-    "grunt-neuter": "~0.6.0",
-    "grunt-release": "git+https://github.com/trek/grunt-release.git#7b766605c85605",
-    "grunt-strip": "~0.2.1",
-    "grunt-strip-node": "~0.1.1",
-    "grunt-testem-mincer": "patocallaghan/grunt-testem-mincer#patoc/update-testem",
-    "matchdep": "~0.1.2",
-    "qunit": "~2.5"
+    "loader.js": "^4.2.3"
   },
-  "version": "3.0.0"
+  "version": "0.0.18"
 }

--- a/packages/ember-model/lib/adapter.js
+++ b/packages/ember-model/lib/adapter.js
@@ -21,3 +21,9 @@ Ember.Adapter = Ember.Object.extend({
     record.load(id, data);
   }
 });
+
+Ember.Adapter.reopenClass({
+  toString() {
+    return `Ember.Adapter`;
+  }
+});

--- a/packages/ember-model/lib/attr.js
+++ b/packages/ember-model/lib/attr.js
@@ -53,7 +53,7 @@ function serialize(value, type) {
 }
 
 Ember.attr = function(type, options) {
-  return Ember.Model.computed("_data", {
+  return Ember.computed("_data", {
     get: function(key){
       var data = get(this, '_data'),
           dataKey = this.dataKey(key),

--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -12,8 +12,7 @@ function storeFor(record) {
   return null;
 }
 
-function getType(record) {
-  var type = this.type;
+function getType(record, type) {
 
   if (typeof this.type === "string" && this.type) {
     type = Ember.get(Ember.lookup, this.type);
@@ -33,10 +32,10 @@ Ember.belongsTo = function(type, options) {
 
   var meta = { type: type, isRelationship: true, options: options, kind: 'belongsTo', getType: getType};
 
-  return Ember.Model.computed("_data", {
+  return Ember.computed("_data", {
     get: function(propertyKey){
-      type = meta.getType(this);
-      Ember.assert("Type cannot be empty.", !Ember.isEmpty(type));
+      var innerType = meta.getType(this, type);
+      Ember.assert("Type cannot be empty.", !Ember.isEmpty(innerType));
 
       var key = options.key || propertyKey,
           self = this;
@@ -50,7 +49,7 @@ Ember.belongsTo = function(type, options) {
       };
 
       var emstore = storeFor(this),
-          value = this.getBelongsTo(key, type, meta, emstore);
+          value = this.getBelongsTo(key, innerType, meta, emstore);
       this._registerBelongsTo(meta);
       if (value !== null && meta.options.embedded) {
         value.get('isDirty'); // getter must be called before adding observer
@@ -60,8 +59,8 @@ Ember.belongsTo = function(type, options) {
     },
 
     set: function(propertyKey, value, oldValue){
-      type = meta.getType(this);
-      Ember.assert("Type cannot be empty.", !Ember.isEmpty(type));
+      var innerType = meta.getType(this, type);
+      Ember.assert("Type cannot be empty.", !Ember.isEmpty(innerType));
 
       var dirtyAttributes = get(this, '_dirtyAttributes'),
           createdDirtyAttributes = false,
@@ -81,7 +80,8 @@ Ember.belongsTo = function(type, options) {
       }
 
       if (value) {
-        Ember.assert('Attempted to set property of type: ' + value.constructor + ' with a value of type: ' + type, value instanceof type);
+        Ember.assert(`Attempted to set property of type: ${value.constructor} with a value of type: ${innerType}`,
+        value instanceof innerType);
       }
 
       if (oldValue !== value) {

--- a/packages/ember-model/tests/adapter/custom_adapter_test.js
+++ b/packages/ember-model/tests/adapter/custom_adapter_test.js
@@ -3,8 +3,13 @@ var CustomModel;
 QUnit.module("Ember.CustomAdapter", {
   beforeEach: function() {
     Ember.CustomAdapter = Ember.Adapter.extend();
+    Ember.CustomAdapter.reopenClass({
+      toString() {
+        return 'Ember.CustomAdapter';
+      }
+    });
     CustomModel = Ember.Model.extend({
-      name: Ember.attr()
+      name: Ember.attr(),
     });
     CustomModel.adapter = Ember.CustomAdapter.create();
   }

--- a/packages/ember-model/tests/adapter/fixture_adapter_test.js
+++ b/packages/ember-model/tests/adapter/fixture_adapter_test.js
@@ -17,10 +17,8 @@ QUnit.test("fetch loads the full FIXTURES payload when id isn't specified", func
       {id: 1, name: 'Erik'},
       {id: 2, name: 'Aaron'}
     ];
-    
-  FixtureModel.FIXTURES = data;
 
-  var done = assert.async();
+  FixtureModel.FIXTURES = data;
   FixtureModel.fetch().then(function(records) {
     assert.equal(records.get('length'), data.length, "The proper number of items should have been loaded.");
     done();
@@ -67,6 +65,7 @@ QUnit.test("createRecord", function(assert) {
   FixtureModel.FIXTURES = [];
 
   var record = FixtureModel.create({name: "Erik"});
+  Ember.setOwner(record, Ember.getOwner(FixtureModel));
 
   assert.ok(record.get('isNew'), "Record should be new");
   assert.ok(!record.get('id'), "Record #id should be undefined");
@@ -86,6 +85,8 @@ QUnit.test("createRecord - handle the case when the `rootKey` property is set", 
   FixtureModel.FIXTURES = [];
 
   var record = FixtureModel.create({name: "Erik"});
+  Ember.setOwner(record, Ember.getOwner(FixtureModel));
+
   var done = assert.async();
 
   Ember.run(record, record.save).then(function () {

--- a/packages/ember-model/tests/adapter/rest_adapter_test.js
+++ b/packages/ember-model/tests/adapter/rest_adapter_test.js
@@ -430,6 +430,7 @@ QUnit.test("createRecord", function(assert) {
   assert.expect(5);
 
   var record = RESTModel.create({name: "Erik"});
+  Ember.setOwner(record, Ember.getOwner(RESTModel));
   // ok(record.get('isDirty'), "Record should be dirty");
   assert.ok(record.get('isNew'), "Record should be new");
 
@@ -451,6 +452,7 @@ QUnit.test("createRecord calls didCreateRecord", function(assert) {
   var record = RESTModel.create({name: "Erik"}),
       args, context, didCreateRecord = adapter.didCreateRecord,
       data = {post: {id: 1, name: "Erik"}};
+  Ember.setOwner(record, Ember.getOwner(RESTModel));
 
   // ok(record.get('isDirty'), "Record should be dirty");
   assert.ok(record.get('isNew'), "Record should be new");
@@ -483,6 +485,8 @@ QUnit.test("createRecord record loads data in response", function(assert) {
     return ajaxSuccess(data);
   };
 
+  Ember.setOwner(record, Ember.getOwner(RESTModel));
+
   Ember.run(record, record.save);
 
   assert.equal(record.get('id'), 1, 'resolved record should have id');
@@ -493,6 +497,7 @@ QUnit.test("saveRecord", function(assert) {
   assert.expect(5);
 
   var record = Ember.run(RESTModel, RESTModel.create, {id: 1, name: "Erik", isNew: false});
+  Ember.setOwner(record, Ember.getOwner(RESTModel));
 
   record.set('name', "Kris");
   assert.ok(record.get('isDirty'), "Record should be dirty");
@@ -514,6 +519,8 @@ QUnit.test("saveRecord calls didSaveRecord after saving record", function(assert
 
   var record = Ember.run(RESTModel, RESTModel.create, {id: 1, name: "Erik", isNew: false}),
       data = {id: 1, name: "Erik"}, args, didSaveRecord = adapter.didSaveRecord, context;
+
+  Ember.setOwner(record, Ember.getOwner(RESTModel));
 
   record.set('name', "Kris");
   assert.ok(record.get('isDirty'), "Record should be dirty");
@@ -542,6 +549,8 @@ QUnit.test("saveRecord loads response data if it exists", function(assert) {
   var record = Ember.run(RESTModel, RESTModel.create, {id: 1, name: "Erik", isNew: false}),
       responseData = {post: {id: 1, name: "Bill"}};
 
+  Ember.setOwner(record, Ember.getOwner(RESTModel));
+
   record.set('name', 'John');
   assert.ok(record.get('isDirty'), 'Record should be dirty');
 
@@ -560,6 +569,8 @@ QUnit.test("saveRecord does not load empty response", function(assert) {
   assert.expect(4);
   var record = Ember.run(RESTModel, RESTModel.create, {id: 1, name: "Erik", isNew: false}),
       responseData = '';
+
+  Ember.setOwner(record, Ember.getOwner(RESTModel));
 
   record.set('name', 'John');
   assert.ok(record.get('isDirty'), 'Record should be dirty');
@@ -580,6 +591,8 @@ QUnit.test("saveRecord does not load HEAD response (undefined response body)", f
   var record = Ember.run(RESTModel, RESTModel.create, {id: 1, name: "Erik", isNew: false}),
       responseData = '';
 
+  Ember.setOwner(record, Ember.getOwner(RESTModel));
+
   record.set('name', 'John');
   assert.ok(record.get('isDirty'), 'Record should be dirty');
 
@@ -598,6 +611,8 @@ QUnit.test("saveRecord does not load response if root key is missing", function(
   assert.expect(4);
   var record = Ember.run(RESTModel, RESTModel.create, {id: 1, name: "Erik", isNew: false}),
       responseData = {notRootKey: true};
+
+  Ember.setOwner(record, Ember.getOwner(RESTModel));
 
   record.set('name', 'John');
   assert.ok(record.get('isDirty'), 'Record should be dirty');

--- a/packages/ember-model/tests/filtered_record_array_test.js
+++ b/packages/ember-model/tests/filtered_record_array_test.js
@@ -1,3 +1,5 @@
+import { start } from "repl";
+
 var Model;
 
 QUnit.module("Ember.FilteredRecordArray", {
@@ -30,7 +32,7 @@ QUnit.test("must be created with a filterFunction property", function(assert) {
 
 QUnit.test("must be created with a filterProperties property", function(assert) {
   assert.throws(function() {
-    Ember.FilteredRecordArray.create({modelClass: Model, filterFunction: function() {} });
+    Ember.FilteredRecordArray.create({modelClass: Model, filterFunction: () => true });
   }, /FilteredRecordArrays must be created with filterProperties/);
 });
 
@@ -83,10 +85,10 @@ QUnit.test("loading a record that doesn't match the filter after creating a Filt
       filterProperties: ['name']
     });
 
-    Model.create({id: 3, name: 'Kris'}).save().then(function(record) {
+    Model.create(owner.ownerInjection(), {id: 3, name: 'Kris'}).save().then(function(record) {
+      start();
       assert.equal(recordArray.get('length'), 1, "There is still 1 record");
       assert.equal(recordArray.get('firstObject.name'), 'Erik', "The record data matches");
-      done();
     });
   });
 
@@ -105,11 +107,11 @@ QUnit.test("loading a record that matches the filter after creating a FilteredRe
       filterProperties: ['name']
     });
 
-    Model.create({id: 3, name: 'Kris'}).save().then(function(record) {
+    Model.create(owner.ownerInjection(), {id: 3, name: 'Kris'}).save().then(function(record) {
+      start();
       assert.equal(recordArray.get('length'), 2, "There are 2 records");
       assert.equal(recordArray.get('firstObject.name'), 'Erik', "The record data matches");
       assert.equal(recordArray.get('lastObject.name'), 'Kris', "The record data matches");
-      done();
     });
   });
 });
@@ -156,7 +158,8 @@ QUnit.test("adding a new record and changing a property that matches the filter 
     assert.equal(recordArray.get('length'), 1, "There is 1 record initially");
     assert.equal(recordArray.get('firstObject.name'), 'Erik', "The record data matches");
 
-    Model.create({id: 3, name: 'Kris'}).save().then(function(record) {
+    Model.create(owner.ownerInjection(), {id: 3, name: 'Kris'}).save().then(function(record) {
+      start();
       record.set('name', 'Ekris');
 
       assert.equal(recordArray.get('length'), 2, "There are 2 records after changing the name");
@@ -171,4 +174,6 @@ QUnit.test("adding a new record and changing a property that matches the filter 
       done();
     });
   });
+
+  stop();
 });

--- a/packages/ember-model/tests/has_many/embedded_objects_load_test.js
+++ b/packages/ember-model/tests/has_many/embedded_objects_load_test.js
@@ -21,8 +21,15 @@ QUnit.test("derp", function(assert) {
   var Article = Ember.Model.extend({
     title: attr(),
 
-    comments: Ember.hasMany(Comment, { key: 'comments', embedded: true })
+    comments: Ember.hasMany('comment', { key: 'comments', embedded: true })
   });
+
+  var owner = buildOwner();
+  Ember.setOwner(Comment, owner);
+  Ember.setOwner(Article, owner);
+  owner.register('model:comment', Comment);
+  owner.register('model:article', Article);
+  owner.register('service:store', Ember.Model.Store);
 
   var article = Article.create();
   Ember.run(article, article.load, json.id, json);
@@ -58,8 +65,15 @@ QUnit.test("loading embedded data into a parent updates the child records", func
 
   var Post = Ember.Model.extend({
     id: attr(),
-    comments: Ember.hasMany(Comment, {key: 'comments', embedded: true})
+    comments: Ember.hasMany('comment', {key: 'comments', embedded: true})
   });
+
+  var owner = buildOwner();
+  Ember.setOwner(Comment, owner);
+  Ember.setOwner(Article, owner);
+  owner.register('model:comment', Comment);
+  owner.register('model:article', Article);
+  owner.register('service:store', Ember.Model.Store);
 
   Post.adapter = {
     find: function(record, id) {

--- a/packages/ember-model/tests/has_many/embedded_objects_save_test.js
+++ b/packages/ember-model/tests/has_many/embedded_objects_save_test.js
@@ -92,12 +92,13 @@ QUnit.test("new records should remain after parent is saved", function(assert) {
       resolve(json);
     });
   };
-  
-  var article = Article.create({
+
+  var owner = buildOwner();
+  var article = Article.create(owner.ownerInjection(), {
     title: 'foo'
   });
 
-  var comment = Comment.create({
+  var comment = Comment.create(owner.ownerInjection(), {
     text: 'comment text'
   });
   article.get('comments').addObject(comment);

--- a/packages/ember-model/tests/has_many/nonembedded_objects_save_test.js
+++ b/packages/ember-model/tests/has_many/nonembedded_objects_save_test.js
@@ -20,7 +20,7 @@ QUnit.test("new records should remain after parent is saved", function(assert) {
   var Article = Ember.Model.extend({
     id: attr(),
     title: attr(),
-    comments: Ember.hasMany(Comment, { key: 'comment_ids' })
+    comments: Ember.hasMany('comment', { key: 'comment_ids' })
   });
   Article.adapter = Ember.RESTAdapter.create();
   Article.url = '/articles';
@@ -30,11 +30,17 @@ QUnit.test("new records should remain after parent is saved", function(assert) {
     });
   };
 
-  var article = Article.create({
+  var owner = buildOwner();
+  Ember.setOwner(Comment, owner);
+  Ember.setOwner(Article, owner);
+  owner.register('service:store', Ember.Model.Store);
+  owner.register('model:comment', Comment);
+  owner.register('model:article', Article);
+  var article = Article.create(owner.ownerInjection(), {
     title: 'bar'
   });
 
-  var comment = Comment.create({
+  var comment = Comment.create(owner.ownerInjection(), {
     text: 'comment text'
   });
 
@@ -73,13 +79,20 @@ QUnit.test("saving child objects", function(assert) {
   var Article = Ember.Model.extend({
     id: attr(),
     title: attr(),
-    comments: Ember.hasMany(Comment, { key: 'comment_ids' })
+    comments: Ember.hasMany('comment', { key: 'comment_ids' })
   });
   Article.adapter = Ember.RESTAdapter.create();
   Article.url = '/articles';
 
-  var article = Article.create();
-  var comment = Comment.create();
+  var owner = buildOwner();
+  Ember.setOwner(Comment, owner);
+  Ember.setOwner(Article, owner);
+  owner.register('service:store', Ember.Model.Store);
+  owner.register('model:comment', Comment);
+  owner.register('model:article', Article);
+
+  var article = Article.create(owner.ownerInjection());
+  var comment = Comment.create(owner.ownerInjection());
 
   var comments = article.get("comments");
   comments.addObject(comment);

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -69,15 +69,22 @@ QUnit.test("using it in a model definition", function(assert) {
 
 QUnit.test("model can be specified with a string instead of a class", function(assert) {
   var Article = Ember.Model.extend({
-      comments: Ember.hasMany('Ember.CommentModel', { key: 'comments', embedded: true })
+      comments: Ember.hasMany('Ecomment', { key: 'comments', embedded: true })
       }),
-      Comment = Ember.CommentModel = Ember.Model.extend({
+      Comment = Ember.Model.extend({
         token: Ember.attr(String)
       });
 
+  var owner = buildOwner();
+  Ember.setOwner(Comment, owner);
+  Ember.setOwner(Article, owner);
+  owner.register('model:article', Article);
+  owner.register('model:comment', Comment);
+  owner.register('service:store', Ember.Model.Store);
+
   Comment.primaryKey = 'token';
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, 1, {comments: Ember.A([{token: 'a'}, {token: 'b'}])});
 
   assert.equal(article.get('comments.length'), 2);
@@ -246,20 +253,30 @@ QUnit.test("has many records created are available from reference cache", functi
   var Company = Ember.Company = Ember.Model.extend({
      id: Ember.attr('string'),
      title: Ember.attr('string'),
-     projects: Ember.hasMany('Ember.Project', {key:'projects', embedded: true})
-  }),
-    Project = Ember.Project = Ember.Model.extend({
-        id: Ember.attr('string'),
-        title: Ember.attr('string'),
-        posts: Ember.hasMany('Ember.Post', {key: 'posts', embedded: true}),
-        company: Ember.belongsTo('Ember.Company', {key:'company'})
-    }),
-    Post = Ember.Post = Ember.Model.extend({
-        id: Ember.attr('string'),
-        title: Ember.attr('string'),
-        body: Ember.attr('string'),
-        project: Ember.belongsTo('Ember.Project', {key:'project'})
-    });
+     projects: Ember.hasMany('project', {key:'projects', embedded: true})
+  });
+  var Project = Ember.Project = Ember.Model.extend({
+    id: Ember.attr('string'),
+    title: Ember.attr('string'),
+    posts: Ember.hasMany('post', {key: 'posts', embedded: true}),
+    company: Ember.belongsTo('company', {key:'company'})
+  });
+  var Post = Ember.Post = Ember.Model.extend({
+    id: Ember.attr('string'),
+    title: Ember.attr('string'),
+    body: Ember.attr('string'),
+    project: Ember.belongsTo('project', {key:'project'})
+  });
+
+  var owner = buildOwner();
+  Ember.setOwner(Company, owner);
+  Ember.setOwner(Project, owner);
+  Ember.setOwner(Post, owner);
+
+  owner.register('model:company', Company);
+  owner.register('model:project', Project);
+  owner.register('model:post', Post);
+  owner.register('service:store', Ember.Model.Store);
 
   var compJson = {
     id:1,

--- a/packages/ember-model/tests/record_array_test.js
+++ b/packages/ember-model/tests/record_array_test.js
@@ -18,6 +18,32 @@ QUnit.module("Ember.RecordArray", {
       {id: 2, name: 'Stefan'},
       {id: 3, name: 'Kris'}
     ];
+    owner = buildOwner();
+    store = Ember.Model.Store.create();
+    Ember.setOwner(store, owner);
+    Ember.setOwner(Model, owner);
+    owner.register('model:test', Model);
+    owner.register('service:store', Ember.Model.Store);
+    data = [
+      {id: 1, name: 'Erik'},
+      {id: 2, name: 'Aaron'}
+    ];
+    RESTModel = Ember.Model.extend({
+      id: Ember.attr(),
+      name: Ember.attr(),
+      type: 'test'
+    });
+    var adapter = Ember.RESTAdapter.create();
+    adapter._ajax = function(url, params, method) {
+      return ajaxSuccess(data);
+    };
+    adapter.findMany = function(klass, records, ids) {
+      return adapter.findAll(klass, records);
+    };
+    RESTModel.adapter = adapter;
+    RESTModel.url = '/fake/api';
+    Ember.setOwner(RESTModel, owner);
+    owner.register('model:test', RESTModel);
   }
 });
 
@@ -238,6 +264,7 @@ QUnit.test("RecordArray handles already inserted new models being saved", functi
   assert.equal(records.get('length'), 1);
 
   var newModel = RESTModel.create();
+  Ember.setOwner(newModel, Ember.getOwner(RESTModel));
 
   records.pushObject(newModel);
 


### PR DESCRIPTION
These changes are copied from CondeNast's fork at https://github.com/CondeNast-Copilot/ember-model, specifically from commit
https://github.com/CondeNast-Copilot/ember-model/commit/9309a9ccc5e1b7a97a464f277670a219e9eedaac.

- Bump addon to 3.0 and make compatible with 3.2
- Remove leaky variable declarations in model#load method
- Don't load embedded polymorphic relationships in method#load (no necessary and causes collisions)
- Fix tests and travis setup