### PR TITLE
Fix concurrency bug when fetching and creating models simultaneously.

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -525,7 +525,7 @@ Ember.Model.reopenClass({
       }
     }
 
-    var records = this._findAllRecordArray = Ember.RecordArray.create({modelClass: this});
+    var records = this._findAllRecordArray = Ember.RecordArray.create({modelClass: this, content: Ember.A()});
     Ember.setOwner(records, owner);
 
     var promise = this._currentFindFetchAllPromise = this.adapter.findAll(this, records);

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -935,6 +935,23 @@ QUnit.test(".clearCache destroys _findAllRecordArray reference", function(assert
     done();
   });
 });
+
+QUnit.test("didCreateRecord does not fail when finding all", function(assert) {
+  var SlowFetchAdapter = Ember.Adapter.extend({
+    findAll: function(klass, records) {
+      return new Ember.RSVP.Promise(function(resolve) {
+        setTimeout(resolve, records, 5000);
+      });
+    }
+  });
+
+  var SlowFetchModel = Ember.Model.extend({}).reopenClass({ adapter: SlowFetchAdapter.create() });
+
+  SlowFetchModel.findAll();
+  SlowFetchModel.create({}).didCreateRecord();
+  assert.ok('No errors thrown');
+});
+
 // // TODO: test that creating a record calls load
 //
 // // QUnit.test('Model#registerRecordArray', function(){


### PR DESCRIPTION
This PR fixes a bug we've encountered where `Model.create` will fail if there is an in-progress `findAll`. If fails with the following error (for future Googlers):

```
TypeError: Cannot read property 'replace' of null
    at o.replaceContent (vendor.js.gz:3749)
    at o.replace (vendor.js.gz:3749)
    at o.insertAt (vendor.js.gz:3704)
    at o.pushObject (vendor.js.gz:3704)
    at o.addObject (vendor.js.gz:3717)
    at Function.addToRecordArrays (vendor.js.gz:8109)
    at o.didCreateRecord (vendor.js.gz:8067)
    at VM6860 Script snippet %2311:13
```

The fix was fairly simple. We set the `content` of the temporary `_findAllRecordArray` to have a default `content` so that when we attempt to push into the record array, it does not fail.

Notes:
* Added failing test.
* Fixed failing test.